### PR TITLE
SCRUM-115: API 응답 통일 구현

### DIFF
--- a/src/main/java/com/team_nebula/nebula/global/apipayload/ApiResponse.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/ApiResponse.java
@@ -1,0 +1,35 @@
+package com.team_nebula.nebula.global.apipayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.team_nebula.nebula.global.apipayload.code.status.SuccessStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+	@JsonProperty("isSuccess")
+	private final Boolean isSuccess;
+	private final String code;
+	private final String message;
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private T result;
+
+	public static <T> ApiResponse<T> onSuccess(T result) {
+		return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), result);
+	}
+
+	public static <T> ApiResponse<T> onSuccessCreated(T result) {
+		return new ApiResponse<>(true, SuccessStatus._CRATED.getCode(), SuccessStatus._CRATED.getMessage(), result);
+	}
+
+	public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
+		return new ApiResponse<>(false, code, message, data);
+	}
+}

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/BaseErrorCode.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/BaseErrorCode.java
@@ -1,0 +1,6 @@
+package com.team_nebula.nebula.global.apipayload.code;
+
+public interface BaseErrorCode {
+	ErrorReasonDto getReason();
+	ErrorReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/ErrorReasonDto.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/ErrorReasonDto.java
@@ -1,0 +1,17 @@
+package com.team_nebula.nebula.global.apipayload.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class ErrorReasonDto {
+	String message;
+	String code;
+	Boolean isSuccess;
+	HttpStatus httpStatus;
+}

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -1,0 +1,41 @@
+package com.team_nebula.nebula.global.apipayload.code.status;
+
+import org.springframework.http.HttpStatus;
+
+import com.team_nebula.nebula.global.apipayload.code.BaseErrorCode;
+import com.team_nebula.nebula.global.apipayload.code.ErrorReasonDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+	_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON5000", "서버 에러. 관리자에게 문의하세요."),
+	_BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON4000", "잘못된 요청"),
+	_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "사용자가 없습니다.");
+
+	private HttpStatus httpStatus;
+	private String code;
+	private String message;
+
+	@Override
+	public ErrorReasonDto getReason() {
+		return ErrorReasonDto.builder()
+			.message(message)
+			.code(code)
+			.isSuccess(false)
+			.build();
+	}
+
+	@Override
+	public ErrorReasonDto getReasonHttpStatus() {
+		return ErrorReasonDto.builder()
+			.message(message)
+			.code(code)
+			.isSuccess(false)
+			.httpStatus(httpStatus)
+			.build();
+	}
+}

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/SuccessStatus.java
@@ -1,0 +1,17 @@
+package com.team_nebula.nebula.global.apipayload.code.status;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus {
+	_OK(HttpStatus.OK, "200", "OK"),
+	_CRATED(HttpStatus.CREATED, "201", "Created");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/exception/ExceptionAdvice.java
@@ -1,0 +1,128 @@
+package com.team_nebula.nebula.global.apipayload.exception;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import com.team_nebula.nebula.global.apipayload.ApiResponse;
+import com.team_nebula.nebula.global.apipayload.code.ErrorReasonDto;
+import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+	@ExceptionHandler
+	public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+		String errorMessage = e.getConstraintViolations().stream()
+			.map(constraintViolation -> constraintViolation.getMessage())
+			.findFirst()
+			.orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+		return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(
+		MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+		Map<String, String> errors = new LinkedHashMap<>();
+
+		ex.getBindingResult().getFieldErrors().stream()
+			.forEach(fieldError -> {
+				String fieldName = fieldError.getField();
+				String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+				errors.merge(fieldName, errorMessage,
+					(existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+			});
+
+		return handleExceptionInternalArgs(ex, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
+	}
+
+	@ExceptionHandler
+	public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+		e.printStackTrace();
+
+		return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY,
+			ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());
+	}
+
+	@ExceptionHandler(value = GeneralException.class)
+	public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+		ErrorReasonDto errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+		return handleExceptionInternal(generalException, errorReasonHttpStatus, null, request);
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDto reason,
+		HttpHeaders headers, HttpServletRequest request) {
+
+		ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null);
+		//        e.printStackTrace();
+
+		WebRequest webRequest = new ServletWebRequest(request);
+		return super.handleExceptionInternal(
+			e,
+			body,
+			headers,
+			reason.getHttpStatus(),
+			webRequest
+		);
+	}
+
+	private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+		HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+		ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(),
+			errorPoint);
+		return super.handleExceptionInternal(
+			e,
+			body,
+			headers,
+			status,
+			request
+		);
+	}
+
+	private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers,
+		ErrorStatus errorCommonStatus,
+		WebRequest request, Map<String, String> errorArgs) {
+		ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(),
+			errorArgs);
+		return super.handleExceptionInternal(
+			e,
+			body,
+			headers,
+			errorCommonStatus.getHttpStatus(),
+			request
+		);
+	}
+
+	private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+		HttpHeaders headers, WebRequest request) {
+		ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(),
+			null);
+		return super.handleExceptionInternal(
+			e,
+			body,
+			headers,
+			errorCommonStatus.getHttpStatus(),
+			request
+		);
+	}
+}
+
+

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/exception/GeneralException.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/exception/GeneralException.java
@@ -1,0 +1,23 @@
+package com.team_nebula.nebula.global.apipayload.exception;
+
+
+import com.team_nebula.nebula.global.apipayload.code.BaseErrorCode;
+import com.team_nebula.nebula.global.apipayload.code.ErrorReasonDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+	private BaseErrorCode code;
+
+	public ErrorReasonDto getErrorReason() {
+		return this.code.getReason();
+	}
+
+	public ErrorReasonDto getErrorReasonHttpStatus() {
+		return this.code.getReasonHttpStatus();
+	}
+}


### PR DESCRIPTION
## 💡 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
API 응답 통일을 위해 응답 템플릿 구현 및 에러 핸들러 초기 세팅

## 🔨작업 사항
<!---- 어떤 변경 사항이 있나요?-->
<img width="316" alt="image" src="https://github.com/user-attachments/assets/b11bad74-bfe4-430d-a413-b2bae57d9530" />

## 📝 기타 (선택)
<!---- 참고 사항이나 리뷰어에게 전달하고 싶은 내용이 있나요?-->

### Sucess 응답 예시

<img width="398" alt="image" src="https://github.com/user-attachments/assets/577dd574-5e31-4625-90d9-f52aed5a5da2" />

200 OK
<img width="214" alt="image" src="https://github.com/user-attachments/assets/60f055a7-0107-491b-af33-aa821ffcc405" />

<img width="466" alt="image" src="https://github.com/user-attachments/assets/f3a269ae-512f-4d4a-848d-fcbf705e7d79" />

201 Created
<img width="220" alt="image" src="https://github.com/user-attachments/assets/127a0510-315a-4a34-817c-ee7fc6372f99" />

---

### Error 응답 예시

에러 커스텀을 위해 ErrorStatus에 Enum 필드 추가
<img width="879" alt="image" src="https://github.com/user-attachments/assets/63902206-0ebf-4d46-b0de-860fb881b240" />

<img width="530" alt="image" src="https://github.com/user-attachments/assets/7d22b783-8568-4aea-b3d5-2c806bd25ac3" />


예시 이미지)
<img width="219" alt="image" src="https://github.com/user-attachments/assets/483cfdd4-eaa6-482c-a271-efa0ddbae937" />
