### PR TITLE
SCRUM 118 : 도메인 노드 세팅 및 Neo4j, MySQL Config 구현

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/category/entity/Category.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/entity/Category.java
@@ -1,0 +1,31 @@
+package com.team_nebula.nebula.domain.category.entity;
+
+import com.team_nebula.nebula.domain.common.BaseEntity;
+import com.team_nebula.nebula.domain.star.entity.Star;
+import jakarta.persistence.GeneratedValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Node
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category extends BaseEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @Relationship(type = "BELONGS_TO", direction = Relationship.Direction.INCOMING)
+    private Set<Star> stars = new HashSet<>();
+}

--- a/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.team_nebula.nebula.domain.category.repository;
+
+import com.team_nebula.nebula.domain.category.entity.Category;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface CategoryRepository extends Neo4jRepository<Category, Long> {
+}

--- a/src/main/java/com/team_nebula/nebula/domain/common/BaseEntity.java
+++ b/src/main/java/com/team_nebula/nebula/domain/common/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.team_nebula.nebula.domain.common;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.neo4j.core.schema.Property;
+
+import java.time.LocalDateTime;
+
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Property("created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Property("updated_at")
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/entity/Keyword.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/entity/Keyword.java
@@ -1,0 +1,23 @@
+package com.team_nebula.nebula.domain.keyword.entity;
+
+import com.team_nebula.nebula.domain.common.BaseEntity;
+import jakarta.persistence.GeneratedValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+
+@Node
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Keyword extends BaseEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -1,0 +1,7 @@
+package com.team_nebula.nebula.domain.keyword.repository;
+
+import com.team_nebula.nebula.domain.keyword.entity.Keyword;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface KeywordRepository extends Neo4jRepository<Keyword, Long> {
+}

--- a/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
@@ -1,0 +1,35 @@
+package com.team_nebula.nebula.domain.link.entity;
+
+import com.team_nebula.nebula.domain.common.BaseEntity;
+import jakarta.persistence.GeneratedValue;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Property;
+
+import java.util.List;
+
+@Node
+@Getter
+@Setter
+@NoArgsConstructor
+public class Link extends BaseEntity {
+    @Id
+    @GeneratedValue
+    private long id;
+
+    private int sharedKeywordNum;
+
+    private double similarityScore;
+
+    @Property("linked_nodes_Id")
+    private List<Long> linkedNode;
+
+    public Link(int sharedKeywordNum, double similarityScore, List<Long> linkedNode) {
+        this.sharedKeywordNum = sharedKeywordNum;
+        this.similarityScore = similarityScore;
+        this.linkedNode = linkedNode;
+    }
+}

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -1,0 +1,8 @@
+package com.team_nebula.nebula.domain.link.repository;
+
+import com.team_nebula.nebula.domain.link.entity.Link;
+import jakarta.persistence.Id;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface LinkRepository extends Neo4jRepository<Link, Long> {
+}

--- a/src/main/java/com/team_nebula/nebula/domain/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/oauth/service/CustomOAuth2UserService.java
@@ -9,7 +9,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import com.team_nebula.nebula.domain.user.entity.User;
-import com.team_nebula.nebula.domain.user.repository.UserRepository;
+import com.team_nebula.nebula.domain.user.repository.mysql.UserRepository;
 import com.team_nebula.nebula.domain.oauth.dto.CustomOAuth2User;
 import com.team_nebula.nebula.domain.oauth.dto.GoogleResponseDTO;
 import com.team_nebula.nebula.domain.oauth.dto.KakaoResponseDTO;

--- a/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
@@ -1,0 +1,70 @@
+package com.team_nebula.nebula.domain.star.entity;
+
+import com.team_nebula.nebula.domain.common.BaseEntity;
+import com.team_nebula.nebula.domain.keyword.entity.Keyword;
+import com.team_nebula.nebula.domain.link.entity.Link;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Lob;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Property;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Node
+@Getter
+@Setter
+@NoArgsConstructor
+public class Star extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String title;
+
+    @Property("site_url")
+    private String siteUrl;
+
+    @Property("thumbnail_url")
+    private String thumbnailUrl;
+
+    @Property("summary_ai")
+    private String summaryAI;
+
+    @Lob
+    private String memoUser;
+
+    private int views;
+
+    @Property("html_file_url")
+    private String htmlFileUrl;
+
+    private String embedding;
+
+    @Relationship(type = "LINKED", direction = Relationship.Direction.OUTGOING)
+    private Set<Link> links = new HashSet<>();
+
+    @Relationship(type = "TAGGED", direction = Relationship.Direction.OUTGOING)
+    private Set<Keyword> keywords = new HashSet<>();
+
+    public Star(String title, String siteUrl, String thumbnailUrl, String summaryAI, String memoUser, int views,
+                String htmlFileUrl, String embedding, Set<Link> links, Set<Keyword> keywords) {
+        this.title = title;
+        this.siteUrl = siteUrl;
+        this.thumbnailUrl = thumbnailUrl;
+        this.summaryAI = summaryAI;
+        this.memoUser = memoUser;
+        this.views = views;
+        this.htmlFileUrl = htmlFileUrl;
+        this.embedding = embedding;
+        this.links = links;
+        this.keywords = keywords;
+    }
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarReapository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarReapository.java
@@ -1,0 +1,7 @@
+package com.team_nebula.nebula.domain.star.repository;
+
+import com.team_nebula.nebula.domain.star.entity.Star;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface StarReapository extends Neo4jRepository<Star, Long> {
+}

--- a/src/main/java/com/team_nebula/nebula/domain/user/entity/UserNode.java
+++ b/src/main/java/com/team_nebula/nebula/domain/user/entity/UserNode.java
@@ -1,0 +1,32 @@
+package com.team_nebula.nebula.domain.user.entity;
+
+import com.team_nebula.nebula.domain.category.entity.Category;
+import com.team_nebula.nebula.domain.common.BaseEntity;
+import com.team_nebula.nebula.domain.star.entity.Star;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.neo4j.core.schema.Id;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Node
+public class UserNode extends BaseEntity {
+
+    @Id
+    private Long userId;
+
+    @Relationship(type = "CREATED", direction = Relationship.Direction.OUTGOING)
+    private Set<Star> stars = new HashSet<>();
+
+    @Relationship(type = "GENERATED", direction = Relationship.Direction.OUTGOING)
+    private Set<Category> booksRead = new HashSet<>();
+
+
+}

--- a/src/main/java/com/team_nebula/nebula/domain/user/repository/mysql/UserRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/user/repository/mysql/UserRepository.java
@@ -1,4 +1,4 @@
-package com.team_nebula.nebula.domain.user.repository;
+package com.team_nebula.nebula.domain.user.repository.mysql;
 
 import java.util.Optional;
 

--- a/src/main/java/com/team_nebula/nebula/domain/user/repository/neo4j/UserNodeRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/user/repository/neo4j/UserNodeRepository.java
@@ -1,0 +1,7 @@
+package com.team_nebula.nebula.domain.user.repository.neo4j;
+
+import com.team_nebula.nebula.domain.user.entity.UserNode;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface UserNodeRepository extends Neo4jRepository<UserNode, Long> {
+}

--- a/src/main/java/com/team_nebula/nebula/global/config/MySQLConfig.java
+++ b/src/main/java/com/team_nebula/nebula/global/config/MySQLConfig.java
@@ -1,0 +1,53 @@
+package com.team_nebula.nebula.global.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableJpaRepositories(
+        basePackages = "com.team_nebula.nebula.domain.user.repository.mysql", // MySQL 관련 Repository 위치
+        entityManagerFactoryRef = "mysqlEntityManager",
+        transactionManagerRef = "mysqlTransactionManager"
+)
+public class MySQLConfig {
+
+    @Primary
+    @Bean(name = "mysqlDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource")
+    public DataSource mysqlDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Primary
+    @Bean(name = "mysqlEntityManager")
+    public LocalContainerEntityManagerFactoryBean mysqlEntityManager(
+            EntityManagerFactoryBuilder builder,
+            @Qualifier("mysqlDataSource") DataSource dataSource) {
+        return builder
+                .dataSource(dataSource)
+                .packages("com.team_nebula.nebula.domain") // MySQL Entity 경로
+                .persistenceUnit("mysql")
+                .build();
+    }
+
+    @Primary
+    @Bean(name = "mysqlTransactionManager")
+    public PlatformTransactionManager mysqlTransactionManager(
+            @Qualifier("mysqlEntityManager") EntityManagerFactory entityManagerFactory) {
+        return new JpaTransactionManager(entityManagerFactory);
+    }
+}
+
+

--- a/src/main/java/com/team_nebula/nebula/global/config/Neo4jConfig.java
+++ b/src/main/java/com/team_nebula/nebula/global/config/Neo4jConfig.java
@@ -12,6 +12,7 @@ import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager;
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 @EnableNeo4jAuditing
@@ -35,9 +36,9 @@ public class Neo4jConfig {
 
         Config config = Config.builder()
                 .withMaxConnectionPoolSize(50) // 최대 연결 수
-                .withConnectionAcquisitionTimeout(Duration.ofSeconds(30)) // 연결 대기 시간
-                .withConnectionTimeout(Duration.ofSeconds(15)) // 연결 설정 시간
-                .withMaxTransactionRetryTime(Duration.ofSeconds(15)) // 트랜잭션 재시도 시간
+                .withConnectionAcquisitionTimeout(30, TimeUnit.SECONDS) // 연결 대기 시간 (초 단위)
+                .withConnectionTimeout(15, TimeUnit.SECONDS) // 연결 설정 시간 (초 단위)
+                .withMaxTransactionRetryTime(15, TimeUnit.SECONDS) // 트랜잭션 재시도 시간 (초 단위)
                 .withEncryption() // TLS(SSL) 활성화 (필요시)
                 .build();
 

--- a/src/main/java/com/team_nebula/nebula/global/config/Neo4jConfig.java
+++ b/src/main/java/com/team_nebula/nebula/global/config/Neo4jConfig.java
@@ -10,8 +10,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.neo4j.config.EnableNeo4jAuditing;
 import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager;
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
-
-import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
@@ -39,7 +37,6 @@ public class Neo4jConfig {
                 .withConnectionAcquisitionTimeout(30, TimeUnit.SECONDS) // 연결 대기 시간 (초 단위)
                 .withConnectionTimeout(15, TimeUnit.SECONDS) // 연결 설정 시간 (초 단위)
                 .withMaxTransactionRetryTime(15, TimeUnit.SECONDS) // 트랜잭션 재시도 시간 (초 단위)
-                .withEncryption() // TLS(SSL) 활성화 (필요시)
                 .build();
 
         return GraphDatabase.driver(uri, AuthTokens.basic(username, password), config);

--- a/src/main/java/com/team_nebula/nebula/global/config/Neo4jConfig.java
+++ b/src/main/java/com/team_nebula/nebula/global/config/Neo4jConfig.java
@@ -1,0 +1,52 @@
+package com.team_nebula.nebula.global.config;
+
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.neo4j.config.EnableNeo4jAuditing;
+import org.springframework.data.neo4j.core.transaction.Neo4jTransactionManager;
+import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
+
+import java.time.Duration;
+
+@Configuration
+@EnableNeo4jAuditing
+@EnableNeo4jRepositories(
+        basePackages = {
+                "com.team_nebula.nebula.domain.user.repository.neo4j",
+                "com.team_nebula.nebula.domain.star.repository",
+                "com.team_nebula.nebula.domain.link.repository",
+                "com.team_nebula.nebula.domain.category.repository",
+                "com.team_nebula.nebula.domain.keyword.repository"
+        },
+        transactionManagerRef = "neo4jTransactionManager"
+)
+public class Neo4jConfig {
+
+    @Bean
+    public Driver neo4jDriver(
+            @Value("${spring.neo4j.uri}") String uri,
+            @Value("${spring.neo4j.authentication.username}") String username,
+            @Value("${spring.neo4j.authentication.password}") String password) {
+
+        Config config = Config.builder()
+                .withMaxConnectionPoolSize(50) // 최대 연결 수
+                .withConnectionAcquisitionTimeout(Duration.ofSeconds(30)) // 연결 대기 시간
+                .withConnectionTimeout(Duration.ofSeconds(15)) // 연결 설정 시간
+                .withMaxTransactionRetryTime(Duration.ofSeconds(15)) // 트랜잭션 재시도 시간
+                .withEncryption() // TLS(SSL) 활성화 (필요시)
+                .build();
+
+        return GraphDatabase.driver(uri, AuthTokens.basic(username, password), config);
+    }
+
+    @Bean(name = "neo4jTransactionManager")
+    public Neo4jTransactionManager transactionManager(Driver driver) {
+        return new Neo4jTransactionManager(driver);
+    }
+}
+


### PR DESCRIPTION
## 💡 개요
도메인 세팅 및 Neo4j, MySQL Config 구현

## 🔨작업 사항
![image](https://github.com/user-attachments/assets/cd36d58d-bd35-420e-8b23-5529588bc60f)

- 도메인별 노드 및 관계 정의
- 일단 MySQL의 User와 구분하기 위해 UserNode로 표현함
- UserNode Repository를 구분하기위해 따로 neo4j 패키지안에 넣음. 
-  Neo4j, MySQL Config 구현
 
## 📝 기타 (선택)
- 추후에 논의해서 아예 따로 User와 UserNode 패키지를 정리할지 논의해보면 좋을듯
- 기능 중에 두 개의 데이터베이스를 동시에 사용하는 경우 Config 코드를 구현해놨기때문에 아래 사진처럼 @Transactional 을 이용해 구분하면 좋음 like this
![image](https://github.com/user-attachments/assets/5264da15-aa87-4604-85a9-e2dbdd659977)

- application.yml에 jdbc-url로 수정하고 실행해야 오류 안남
![image](https://github.com/user-attachments/assets/205ffeaf-dad1-4233-b719-21452e5bcbc7)
