### PR TITLE
scrum 126 : 스타 생성 + 전체 및 단일 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+	// AWS S3
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.300'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/team_nebula/nebula/domain/category/api/CategoryController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/api/CategoryController.java
@@ -20,7 +20,7 @@ public class CategoryController {
     private final CategoryQueryService categoryQueryService;
 
     // 카데고리 생성 API
-    @PostMapping("/")
+    @PostMapping("")
     public ApiResponse<CreateCategoryResponseDTO> createCategory(CreateCategoryRequestDTO request) {
         CreateCategoryResponseDTO responseDto = categoryCommandService.createCategory(request);
         return ApiResponse.onSuccessCreated(responseDto);

--- a/src/main/java/com/team_nebula/nebula/domain/category/entity/Category.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/entity/Category.java
@@ -3,10 +3,7 @@ package com.team_nebula.nebula.domain.category.entity;
 import com.team_nebula.nebula.domain.common.BaseEntity;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import jakarta.persistence.GeneratedValue;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.neo4j.core.schema.Node;
 import org.springframework.data.neo4j.core.schema.Relationship;
@@ -16,9 +13,7 @@ import java.util.Set;
 
 @Node
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category extends BaseEntity {
     @Id
     @GeneratedValue
@@ -28,4 +23,9 @@ public class Category extends BaseEntity {
 
     @Relationship(type = "BELONGS_TO", direction = Relationship.Direction.INCOMING)
     private Set<Star> stars = new HashSet<>();
+
+    @Builder
+    public Category(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface CategoryRepository extends Neo4jRepository<Category, Long> {
     boolean existsByName(String name);
@@ -17,5 +18,7 @@ public interface CategoryRepository extends Neo4jRepository<Category, Long> {
     RETURN c.id AS id, c.name AS name, COUNT(s) AS includedStarCnt
     """)
     List<Map<String, Object>> findUserCategoriesWithStarCount(@Param("userId") Long userId);
+
+    Optional<Category> findByName(String name);
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandService.java
@@ -2,8 +2,12 @@ package com.team_nebula.nebula.domain.category.service;
 
 import com.team_nebula.nebula.domain.category.dto.request.CreateCategoryRequestDTO;
 import com.team_nebula.nebula.domain.category.dto.response.CreateCategoryResponseDTO;
+import com.team_nebula.nebula.domain.star.entity.Star;
 
 public interface CategoryCommandService {
 
     public CreateCategoryResponseDTO createCategory(CreateCategoryRequestDTO request);
-}
+
+    public void linkStarToCategory(Star star, String categoryName);
+
+    }

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.team_nebula.nebula.domain.category.dto.request.CreateCategoryRequestD
 import com.team_nebula.nebula.domain.category.dto.response.CreateCategoryResponseDTO;
 import com.team_nebula.nebula.domain.category.entity.Category;
 import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
+import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.domain.user.entity.UserNode;
 import com.team_nebula.nebula.domain.user.repository.neo4j.UserNodeRepository;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
@@ -39,7 +40,7 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
 
         // 유저->카테고리 관계 연결
         userNode.getCategorySet().add(category);
-        categoryRepository.save(category);
+        userNodeRepository.save(userNode);
 
         return CreateCategoryResponseDTO.builder()
                 .categoryId(category.getId())
@@ -48,6 +49,16 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
                 .updatedAt(category.getUpdatedAt())
                 .build();
     }
+
+    @Override
+    public void linkStarToCategory(Star star, String categoryName){
+        Category category = categoryRepository.findByName(categoryName)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CATEGORY_NOT_FOUND));
+
+        category.getStars().add(star);
+        categoryRepository.save(category);
+    }
+
 }
 
 

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
@@ -11,10 +11,12 @@ import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CategoryCommandServiceImpl implements CategoryCommandService {
 
     private final CategoryRepository categoryRepository;
@@ -34,8 +36,9 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
         }
 
         // 카테고리 노드 생성
-        Category category = new Category();
-        category.setName(request.getName());
+        Category category = Category.builder()
+                .name(request.getName())
+                .build();
         categoryRepository.save(category);
 
         // 유저->카테고리 관계 연결

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryQueryServiceImpl.java
@@ -7,12 +7,14 @@ import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CategoryQueryServiceImpl implements CategoryQueryService {
 
     private final CategoryRepository categoryRepository;

--- a/src/main/java/com/team_nebula/nebula/domain/image/S3Service.java
+++ b/src/main/java/com/team_nebula/nebula/domain/image/S3Service.java
@@ -1,0 +1,89 @@
+package com.team_nebula.nebula.domain.image;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
+import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class S3Service {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private static final String THUMBNAIL_DIR = "thumbnails/";
+    private static final String HTML_FILE_DIR = "html_files/";
+
+    public String saveThumbnail(MultipartFile thumbnailImage, String dataInfo) {
+        return uploadToS3(thumbnailImage, THUMBNAIL_DIR, dataInfo);
+    }
+
+    public String saveHtmlFile(MultipartFile htmlFile, String dataInfo) {
+        return uploadToS3(htmlFile, HTML_FILE_DIR, dataInfo);
+    }
+
+    private String uploadToS3(MultipartFile file, String dirName, String dataInfo)  {
+        File uploadFile = convert(file)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MULTIPARTFILE_CONVERT_FAIL));
+
+        String fileName = dirName + dataInfo + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+        String fileUrl = putS3(uploadFile, fileName);
+        removeNewFile(uploadFile);
+        return fileUrl;
+    }
+
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("File delete success");
+        } else {
+            log.warn("File delete fail");
+        }
+    }
+
+    private Optional<File> convert(MultipartFile file) {
+        if (file.isEmpty() || file.getOriginalFilename() == null) {
+            log.error("File is empty or filename is null");
+            return Optional.empty();
+        }
+
+        try {
+            File convertFile = new File(System.getProperty("java.io.tmpdir") + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename());
+            if (convertFile.createNewFile()) {
+                try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                    fos.write(file.getBytes());
+                }
+                return Optional.of(convertFile);
+            } else {
+                log.error("File already exists: {}", convertFile.getAbsolutePath());
+            }
+        } catch (IOException e) {
+            log.error("File conversion failed: {}", e.getMessage());
+        }
+        return Optional.empty();
+    }
+}
+

--- a/src/main/java/com/team_nebula/nebula/domain/image/S3Service.java
+++ b/src/main/java/com/team_nebula/nebula/domain/image/S3Service.java
@@ -42,7 +42,7 @@ public class S3Service {
 
     private String uploadToS3(MultipartFile file, String dirName, String dataInfo)  {
         File uploadFile = convert(file)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MULTIPARTFILE_CONVERT_FAIL));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MULTIPARTFILE_CONVERT_FAIL));
 
         String fileName = dirName + dataInfo + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
         String fileUrl = putS3(uploadFile, fileName);

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/entity/Keyword.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/entity/Keyword.java
@@ -2,22 +2,22 @@ package com.team_nebula.nebula.domain.keyword.entity;
 
 import com.team_nebula.nebula.domain.common.BaseEntity;
 import jakarta.persistence.GeneratedValue;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
 
 @Node
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Keyword extends BaseEntity {
     @Id
     @GeneratedValue
     private Long id;
 
     private String name;
+
+    @Builder
+    public Keyword(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -2,6 +2,18 @@ package com.team_nebula.nebula.domain.keyword.repository;
 
 import com.team_nebula.nebula.domain.keyword.entity.Keyword;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface KeywordRepository extends Neo4jRepository<Keyword, Long> {
+    @Query("""
+        UNWIND $keywordNames AS keywordName
+        MERGE (k:Keyword {name: keywordName})
+        WITH k
+        MATCH (s:Star {id: $starId})
+        MERGE (s)-[:TAGGED]->(k)
+    """)
+    void linkStarToKeywords(@Param("starId") Long starId, @Param("keywordNames") List<String> keywordNames);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandService.java
@@ -1,0 +1,9 @@
+package com.team_nebula.nebula.domain.keyword.service;
+
+import com.team_nebula.nebula.domain.star.entity.Star;
+
+import java.util.List;
+
+public interface KeywordCommandService {
+    public void linkStarToKeywords(Star star, List<String> keywordNames);
+}

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
@@ -1,0 +1,25 @@
+package com.team_nebula.nebula.domain.keyword.service;
+
+import com.team_nebula.nebula.domain.keyword.repository.KeywordRepository;
+import com.team_nebula.nebula.domain.star.entity.Star;
+import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
+import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class KeywordCommandServiceImpl implements KeywordCommandService {
+
+    private final KeywordRepository keywordRepository;
+
+    @Override
+    public void linkStarToKeywords(Star star, List<String> keywordNames) {
+        if (keywordNames == null || keywordNames.isEmpty()) {
+            throw new GeneralException(ErrorStatus._KEYWORD_NOT_FOUND);
+        }
+        keywordRepository.linkStarToKeywords(star.getId(), keywordNames);
+    }
+}

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
@@ -6,11 +6,13 @@ import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class KeywordCommandServiceImpl implements KeywordCommandService {
 
     private final KeywordRepository keywordRepository;

--- a/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
@@ -24,7 +24,7 @@ public class Link extends BaseEntity {
 
     private double similarityScore;
 
-    @Property("linked_nodes_Id")
+    @Property("linked_two_node_Id")
     private List<Long> linkedNode;
 
     public Link(int sharedKeywordNum, double similarityScore, List<Long> linkedNode) {

--- a/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
@@ -2,9 +2,9 @@ package com.team_nebula.nebula.domain.link.entity;
 
 import com.team_nebula.nebula.domain.common.BaseEntity;
 import jakarta.persistence.GeneratedValue;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
 import org.springframework.data.neo4j.core.schema.Property;
@@ -13,7 +13,6 @@ import java.util.List;
 
 @Node
 @Getter
-@Setter
 @NoArgsConstructor
 public class Link extends BaseEntity {
     @Id
@@ -27,6 +26,7 @@ public class Link extends BaseEntity {
     @Property("linked_two_node_Id")
     private List<Long> linkedNode;
 
+    @Builder
     public Link(int sharedKeywordNum, double similarityScore, List<Long> linkedNode) {
         this.sharedKeywordNum = sharedKeywordNum;
         this.similarityScore = similarityScore;

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -1,8 +1,21 @@
 package com.team_nebula.nebula.domain.link.repository;
 
 import com.team_nebula.nebula.domain.link.entity.Link;
-import jakarta.persistence.Id;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LinkRepository extends Neo4jRepository<Link, Long> {
+
+    @Query("""
+        MATCH (s1:Star)-[:HAS_KEYWORD]->(k:Keyword)<-[:HAS_KEYWORD]-(s2:Star)
+        WHERE s1.id = $starId AND s1 <> s2
+        WITH s1, s2, COUNT(k) AS sharedKeywordNum
+        WHERE sharedKeywordNum > 0
+        MERGE (l:Link {linked_two_node_Id: [s1.id, s2.id]})
+        ON CREATE SET l.sharedKeywordNum = sharedKeywordNum, l.similarityScore = 0.5
+        MERGE (s1)-[:LINKED]->(l)
+        MERGE (s2)-[:LINKED]->(l)
+    """)
+    void createLinksBetweenStars(@Param("starId") Long starId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.query.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+import java.util.Map;
+
 public interface LinkRepository extends Neo4jRepository<Link, Long> {
 
     @Query("""
@@ -18,4 +21,13 @@ public interface LinkRepository extends Neo4jRepository<Link, Long> {
         MERGE (s2)-[:LINKED]->(l)
     """)
     void createLinksBetweenStars(@Param("starId") Long starId);
+
+    @Query("""
+        MATCH (s:Star)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
+        WHERE s.userId = $userId OR s2.userId = $userId
+        RETURN l, l.linked_two_node_Id AS linkedNodeIdList, 
+               l.sharedKeywordNum AS sharedKeywordNum, 
+               l.similarityScore AS similarity
+    """)
+    List<Map<String, Object>> findLinksByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkCommandService.java
@@ -1,0 +1,8 @@
+package com.team_nebula.nebula.domain.link.service;
+
+import com.team_nebula.nebula.domain.star.entity.Star;
+
+public interface LinkCommandService {
+
+    public void createLinksForStar(Star star);
+}

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkCommandServiceImpl.java
@@ -1,0 +1,19 @@
+package com.team_nebula.nebula.domain.link.service;
+
+import com.team_nebula.nebula.domain.link.repository.LinkRepository;
+import com.team_nebula.nebula.domain.star.entity.Star;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LinkCommandServiceImpl implements LinkCommandService{
+
+    private final LinkRepository linkRepository;
+
+    @Override
+    public void createLinksForStar(Star star) {
+        linkRepository.createLinksBetweenStars(star.getId());
+    }
+
+}

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkCommandServiceImpl.java
@@ -4,9 +4,11 @@ import com.team_nebula.nebula.domain.link.repository.LinkRepository;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class LinkCommandServiceImpl implements LinkCommandService{
 
     private final LinkRepository linkRepository;

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryService.java
@@ -1,0 +1,10 @@
+package com.team_nebula.nebula.domain.link.service;
+
+import com.team_nebula.nebula.domain.star.dto.response.GetLinkOneResponseDTO;
+import com.team_nebula.nebula.domain.user.entity.UserNode;
+
+import java.util.List;
+
+public interface LinkQueryService {
+    public List<GetLinkOneResponseDTO> getAllLink(UserNode userNode);
+}

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
@@ -6,12 +6,14 @@ import com.team_nebula.nebula.domain.star.dto.response.GetLinkOneResponseDTO;
 import com.team_nebula.nebula.domain.user.entity.UserNode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class LinkQueryServiceImpl implements LinkQueryService {
 
     private final LinkRepository linkRepository;

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
@@ -1,0 +1,34 @@
+package com.team_nebula.nebula.domain.link.service;
+
+import com.team_nebula.nebula.domain.link.entity.Link;
+import com.team_nebula.nebula.domain.link.repository.LinkRepository;
+import com.team_nebula.nebula.domain.star.dto.response.GetLinkOneResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
+import com.team_nebula.nebula.domain.user.entity.UserNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class LinkQueryServiceImpl implements LinkQueryService {
+
+    private final LinkRepository linkRepository;
+
+    @Override
+    public List<GetLinkOneResponseDTO> getAllLink(UserNode userNode){
+        List<Map<String, Object>> linkDataList = linkRepository.findLinksByUserId(userNode.getUserId());
+
+        return linkDataList.stream()
+                .map(data -> GetLinkOneResponseDTO.builder()
+                        .linkId(((Link) data.get("l")).getId())
+                        .sharedKeywordNum((int) data.get("sharedKeywordNum"))
+                        .similarity((double) data.get("similarity"))
+                        .linkedNodeIdList((List<Long>) data.get("linkedNodeIdList"))
+                        .build())
+                .toList();
+
+    }
+}

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
@@ -3,7 +3,6 @@ package com.team_nebula.nebula.domain.link.service;
 import com.team_nebula.nebula.domain.link.entity.Link;
 import com.team_nebula.nebula.domain.link.repository.LinkRepository;
 import com.team_nebula.nebula.domain.star.dto.response.GetLinkOneResponseDTO;
-import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
 import com.team_nebula.nebula.domain.user.entity.UserNode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +16,7 @@ public class LinkQueryServiceImpl implements LinkQueryService {
 
     private final LinkRepository linkRepository;
 
+    // 링크 노드 전체 조회
     @Override
     public List<GetLinkOneResponseDTO> getAllLink(UserNode userNode){
         List<Map<String, Object>> linkDataList = linkRepository.findLinksByUserId(userNode.getUserId());

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -21,7 +21,7 @@ public class StarController {
     private final StarCommandService starCommandService;
     private final StarQueryService starQueryService;
 
-    @PostMapping("/")
+    @PostMapping("")
     public ApiResponse<CreateStarResponseDTO> createStar(
             @RequestPart(value = "thumbnailImage",required = false) MultipartFile thumbnailImage,
             @RequestPart(value = "htmlFile",required = false) MultipartFile htmlFile,

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -1,0 +1,33 @@
+package com.team_nebula.nebula.domain.star.api;
+
+import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
+import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
+import com.team_nebula.nebula.domain.star.service.StarCommandService;
+import com.team_nebula.nebula.domain.star.service.StarQueryService;
+import com.team_nebula.nebula.global.apipayload.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "[ 스타 ]")
+@RequestMapping("/api/v1/bookmarks")
+public class StarController {
+
+    private final StarCommandService starCommandService;
+    private final StarQueryService starQueryService;
+
+    @PostMapping("/")
+    public ApiResponse<CreateStarResponseDTO> createStar(
+            @RequestPart(value = "thumbnailImage",required = false) MultipartFile thumbnailImage,
+            @RequestPart(value = "htmlFile",required = false) MultipartFile htmlFile,
+            @RequestPart(value = "star JSON data") String starJsonData
+    ){
+        CreateStarFileDTO requestDTO = starQueryService.starDataParsing(thumbnailImage, htmlFile, starJsonData);
+
+        CreateStarResponseDTO responseDTO = starCommandService.createStar(requestDTO);
+        return ApiResponse.onSuccessCreated(responseDTO);
+    }
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -2,6 +2,7 @@ package com.team_nebula.nebula.domain.star.api;
 
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.GetStarListResponseDTO;
 import com.team_nebula.nebula.domain.star.service.StarCommandService;
 import com.team_nebula.nebula.domain.star.service.StarQueryService;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
@@ -28,6 +29,13 @@ public class StarController {
         CreateStarFileDTO requestDTO = starQueryService.starDataParsing(thumbnailImage, htmlFile, starJsonData);
 
         CreateStarResponseDTO responseDTO = starCommandService.createStar(requestDTO);
+        return ApiResponse.onSuccessCreated(responseDTO);
+    }
+
+    @GetMapping("/{userId}")
+    public ApiResponse<GetStarListResponseDTO> getStars(@PathVariable Long userId){
+        GetStarListResponseDTO responseDTO = starQueryService.getStarList(userId);
+
         return ApiResponse.onSuccessCreated(responseDTO);
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -3,6 +3,7 @@ package com.team_nebula.nebula.domain.star.api;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetStarListResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
 import com.team_nebula.nebula.domain.star.service.StarCommandService;
 import com.team_nebula.nebula.domain.star.service.StarQueryService;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
@@ -33,9 +34,16 @@ public class StarController {
     }
 
     @GetMapping("/{userId}")
-    public ApiResponse<GetStarListResponseDTO> getStars(@PathVariable Long userId){
+    public ApiResponse<GetStarListResponseDTO> getStarList(@PathVariable Long userId){
         GetStarListResponseDTO responseDTO = starQueryService.getStarList(userId);
 
-        return ApiResponse.onSuccessCreated(responseDTO);
+        return ApiResponse.onSuccess(responseDTO);
+    }
+
+    @GetMapping("/{starId}")
+    public ApiResponse<GetStarOneResponseDTO> getStarOne(@PathVariable Long starId){
+        GetStarOneResponseDTO responseDTO = starQueryService.getStarOne(starId);
+
+        return ApiResponse.onSuccess(responseDTO);
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/converter/StarConverter.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/converter/StarConverter.java
@@ -1,0 +1,26 @@
+package com.team_nebula.nebula.domain.star.converter;
+
+import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
+import com.team_nebula.nebula.domain.star.entity.Star;
+
+import java.util.List;
+import java.util.Map;
+
+public class StarConverter {
+
+    public static GetStarOneResponseDTO convertToStarOneDto(Map<String, Object> data) {
+        Star star = (Star) data.get("s");
+
+        return GetStarOneResponseDTO.builder()
+                .starId(star.getId())
+                .categoryName((String) data.get("categoryName"))
+                .title(star.getTitle())
+                .siteUrl(star.getSiteUrl())
+                .thumbnailUrl(star.getThumbnailUrl())
+                .summaryAI(star.getSummaryAI())
+                .userMemo(star.getUserMemo())
+                .views(star.getViews())
+                .keywordList((List<String>) data.get("keywordList"))
+                .build();
+    }
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarFileDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarFileDTO.java
@@ -1,11 +1,11 @@
 package com.team_nebula.nebula.domain.star.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
-@Setter
+@Builder
 public class CreateStarFileDTO {
     private MultipartFile thumbnailImage;
     private MultipartFile htmlFile;

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarFileDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarFileDTO.java
@@ -1,0 +1,13 @@
+package com.team_nebula.nebula.domain.star.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class CreateStarFileDTO {
+    private MultipartFile thumbnailImage;
+    private MultipartFile htmlFile;
+    private CreateStarRequestDTO starRequestDTO;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
@@ -1,0 +1,25 @@
+package com.team_nebula.nebula.domain.star.dto.request;
+
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class CreateStarRequestDTO {
+
+    private Long userId;
+    private String title;
+    private String siteUrl;
+    private String summaryAI;
+    private String userMemo;
+    private String embedding;
+    private String categoryName;
+    private List<String> keywordList;
+
+    public String getSummaryAI() {
+        return (summaryAI == null || summaryAI.isBlank()) ? "No summary provided" : summaryAI;
+    }
+
+    public String getUserMemo() {
+        return (userMemo == null || userMemo.isBlank()) ? "No memo provided" : userMemo;
+    }
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
@@ -1,9 +1,11 @@
 package com.team_nebula.nebula.domain.star.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
 import java.util.List;
 
 @Getter
+@Builder
 public class CreateStarRequestDTO {
 
     private Long userId;

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
@@ -16,10 +16,18 @@ public class CreateStarRequestDTO {
     private List<String> keywordList;
 
     public String getSummaryAI() {
-        return (summaryAI == null || summaryAI.isBlank()) ? "No summary provided" : summaryAI;
+        if (summaryAI == null || summaryAI.isBlank()) {
+            return "사용자가 AI요약을 하지 않았습니다.";
+        } else {
+            return summaryAI;
+        }
     }
 
     public String getUserMemo() {
-        return (userMemo == null || userMemo.isBlank()) ? "No memo provided" : userMemo;
+        if (userMemo == null || userMemo.isBlank()) {
+            return "사용자가 메모를 입력하지 않았습니다.";
+        } else {
+            return userMemo;
+        }
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/CreateStarResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/CreateStarResponseDTO.java
@@ -1,0 +1,21 @@
+package com.team_nebula.nebula.domain.star.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateStarResponseDTO {
+
+    private Long starId;
+    private String title;
+    private String categoryName;
+    private List<String> keywordList;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetLinkOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetLinkOneResponseDTO.java
@@ -11,10 +11,14 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class CreateStarResponseDTO {
-
+public class GetLinkOneResponseDTO {
     private Long starId;
-    private String title;
     private String categoryName;
+    private String title;
+    private String siteUrl;
+    private String thumbnailUrl;
+    private String summaryAI;
+    private String userMemo;
+    private int views;
     private List<String> keywordList;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetLinkOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetLinkOneResponseDTO.java
@@ -12,13 +12,8 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GetLinkOneResponseDTO {
-    private Long starId;
-    private String categoryName;
-    private String title;
-    private String siteUrl;
-    private String thumbnailUrl;
-    private String summaryAI;
-    private String userMemo;
-    private int views;
-    private List<String> keywordList;
+    private Long linkId;
+    private int sharedKeywordNum;
+    private double similarity;
+    private List<Long> linkedNodeIdList;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetStarListResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetStarListResponseDTO.java
@@ -11,10 +11,9 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class CreateStarResponseDTO {
-
-    private Long starId;
-    private String title;
-    private String categoryName;
-    private List<String> keywordList;
+public class GetStarListResponseDTO {
+    private int totalStarCnt;
+    private int totalLinkCnt;
+    private List<GetStarOneResponseDTO> starListDto;
+    private List<GetLinkOneResponseDTO> linkListDto;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetStarOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetStarOneResponseDTO.java
@@ -11,10 +11,9 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class CreateStarResponseDTO {
-
-    private Long starId;
-    private String title;
-    private String categoryName;
-    private List<String> keywordList;
+public class GetStarOneResponseDTO {
+    private Long linkId;
+    private int sharedKeywordNum;
+    private double similarityScore;
+    private List<Long> linkedNodeIdList;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetStarOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetStarOneResponseDTO.java
@@ -12,8 +12,13 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GetStarOneResponseDTO {
-    private Long linkId;
-    private int sharedKeywordNum;
-    private double similarityScore;
-    private List<Long> linkedNodeIdList;
+    private Long starId;
+    private String categoryName;
+    private String title;
+    private String siteUrl;
+    private String thumbnailUrl;
+    private String summaryAI;
+    private String userMemo;
+    private int views;
+    private List<String> keywordList;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
@@ -5,7 +5,6 @@ import com.team_nebula.nebula.domain.keyword.entity.Keyword;
 import com.team_nebula.nebula.domain.link.entity.Link;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Lob;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -39,8 +38,9 @@ public class Star extends BaseEntity {
     private String summaryAI;
 
     @Lob
-    private String memoUser;
+    private String userMemo;
 
+    // 조회수
     private int views;
 
     @Property("html_file_url")
@@ -60,7 +60,7 @@ public class Star extends BaseEntity {
         this.siteUrl = siteUrl;
         this.thumbnailUrl = thumbnailUrl;
         this.summaryAI = summaryAI;
-        this.memoUser = memoUser;
+        this.userMemo = memoUser;
         this.views = views;
         this.htmlFileUrl = htmlFileUrl;
         this.embedding = embedding;

--- a/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
@@ -5,9 +5,9 @@ import com.team_nebula.nebula.domain.keyword.entity.Keyword;
 import com.team_nebula.nebula.domain.link.entity.Link;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Lob;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
 import org.springframework.data.neo4j.core.schema.Property;
@@ -18,7 +18,6 @@ import java.util.Set;
 
 @Node
 @Getter
-@Setter
 @NoArgsConstructor
 public class Star extends BaseEntity {
 
@@ -54,17 +53,17 @@ public class Star extends BaseEntity {
     @Relationship(type = "TAGGED", direction = Relationship.Direction.OUTGOING)
     private Set<Keyword> keywords = new HashSet<>();
 
-    public Star(String title, String siteUrl, String thumbnailUrl, String summaryAI, String memoUser, int views,
-                String htmlFileUrl, String embedding, Set<Link> links, Set<Keyword> keywords) {
+    @Builder
+    public Star(String title, String siteUrl, String thumbnailUrl, String summaryAI, String userMemo, String memoUser, int views,
+                String htmlFileUrl, String embedding) {
         this.title = title;
         this.siteUrl = siteUrl;
         this.thumbnailUrl = thumbnailUrl;
         this.summaryAI = summaryAI;
+        this.userMemo = userMemo;
         this.userMemo = memoUser;
         this.views = views;
         this.htmlFileUrl = htmlFileUrl;
         this.embedding = embedding;
-        this.links = links;
-        this.keywords = keywords;
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface StarRepository extends Neo4jRepository<Star, Long> {
     @Query("""
@@ -19,4 +20,12 @@ public interface StarRepository extends Neo4jRepository<Star, Long> {
                COLLECT(k.name) AS keywordList
     """)
     List<Map<String, Object>> findStarsByUserId(@Param("userId") Long userId);
+
+    @Query("""
+        MATCH (s:Star)-[:BELONGS_TO]->(c:Category)
+        OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
+        WHERE ID(s) = $starId
+        RETURN s AS s, c.name AS categoryName, COLLECT(k.name) AS keywordList
+    """)
+    Optional<Map<String, Object>> findStarDetailById(@Param("starId") Long starId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
@@ -3,5 +3,5 @@ package com.team_nebula.nebula.domain.star.repository;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 
-public interface StarReapository extends Neo4jRepository<Star, Long> {
+public interface StarRepository extends Neo4jRepository<Star, Long> {
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
@@ -2,6 +2,21 @@ package com.team_nebula.nebula.domain.star.repository;
 
 import com.team_nebula.nebula.domain.star.entity.Star;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Map;
 
 public interface StarRepository extends Neo4jRepository<Star, Long> {
+    @Query("""
+        MATCH (u:UserNode)-[:CREATED]->(s:Star)
+        WHERE u.userId = $userId
+        OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
+        OPTIONAL MATCH (s)-[:BELONGS_TO]->(c:Category)
+        RETURN s, 
+               c.name AS categoryName, 
+               COLLECT(k.name) AS keywordList
+    """)
+    List<Map<String, Object>> findStarsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -1,0 +1,9 @@
+package com.team_nebula.nebula.domain.star.service;
+
+import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
+import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
+
+public interface StarCommandService {
+
+    public CreateStarResponseDTO createStar(CreateStarFileDTO requestDTO);
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -1,9 +1,8 @@
 package com.team_nebula.nebula.domain.star.service;
 
-import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
 import com.team_nebula.nebula.domain.category.service.CategoryCommandService;
+import com.team_nebula.nebula.domain.image.S3Service;
 import com.team_nebula.nebula.domain.keyword.entity.Keyword;
-import com.team_nebula.nebula.domain.keyword.repository.KeywordRepository;
 import com.team_nebula.nebula.domain.keyword.service.KeywordCommandService;
 import com.team_nebula.nebula.domain.link.service.LinkCommandService;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
@@ -27,6 +26,7 @@ public class StarCommandServiceImpl implements StarCommandService {
     private final CategoryCommandService categoryCommandService;
     private final KeywordCommandService keywordCommandService;
     private final LinkCommandService linkCommandService;
+    private final S3Service s3Service;
 
     @Override
     public CreateStarResponseDTO createStar(CreateStarFileDTO requestDTO){
@@ -65,8 +65,8 @@ public class StarCommandServiceImpl implements StarCommandService {
         Star star = new Star();
         star.setTitle(starRequestDTO.getTitle());
         star.setSiteUrl(starRequestDTO.getSiteUrl());
-        star.setThumbnailUrl(s3Service.uploadFile(requestDTO.getThumbnailImage()));
-        star.setHtmlFileUrl(s3Service.uploadFile(requestDTO.getHtmlFile()));
+        star.setThumbnailUrl(s3Service.saveThumbnail(requestDTO.getThumbnailImage(), starRequestDTO.getTitle()));
+        star.setHtmlFileUrl(s3Service.saveHtmlFile(requestDTO.getHtmlFile(), starRequestDTO.getTitle()));
         star.setSummaryAI(starRequestDTO.getSummaryAI());
         star.setUserMemo(starRequestDTO.getUserMemo());
         star.setViews(0);

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -16,9 +16,11 @@ import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class StarCommandServiceImpl implements StarCommandService {
 
     private final StarRepository starRepository;
@@ -62,15 +64,16 @@ public class StarCommandServiceImpl implements StarCommandService {
     public Star createStarEntity(CreateStarFileDTO requestDTO, UserNode userNode){
         CreateStarRequestDTO starRequestDTO = requestDTO.getStarRequestDTO();
 
-        Star star = new Star();
-        star.setTitle(starRequestDTO.getTitle());
-        star.setSiteUrl(starRequestDTO.getSiteUrl());
-        star.setThumbnailUrl(s3Service.saveThumbnail(requestDTO.getThumbnailImage(), starRequestDTO.getTitle()));
-        star.setHtmlFileUrl(s3Service.saveHtmlFile(requestDTO.getHtmlFile(), starRequestDTO.getTitle()));
-        star.setSummaryAI(starRequestDTO.getSummaryAI());
-        star.setUserMemo(starRequestDTO.getUserMemo());
-        star.setViews(0);
-        star.setEmbedding(starRequestDTO.getEmbedding());
+        Star star = Star.builder()
+                .title(starRequestDTO.getTitle())
+                .siteUrl(starRequestDTO.getSiteUrl())
+                .thumbnailUrl(s3Service.saveThumbnail(requestDTO.getThumbnailImage(), starRequestDTO.getTitle()))
+                .htmlFileUrl(s3Service.saveHtmlFile(requestDTO.getHtmlFile(), starRequestDTO.getTitle()))
+                .summaryAI(starRequestDTO.getSummaryAI())
+                .userMemo(starRequestDTO.getUserMemo())
+                .views(0)
+                .embedding(starRequestDTO.getEmbedding())
+                .build();
 
         Star savedStar = starRepository.save(star);
         if (savedStar.getId() == null) {

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -1,0 +1,87 @@
+package com.team_nebula.nebula.domain.star.service;
+
+import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
+import com.team_nebula.nebula.domain.category.service.CategoryCommandService;
+import com.team_nebula.nebula.domain.keyword.entity.Keyword;
+import com.team_nebula.nebula.domain.keyword.repository.KeywordRepository;
+import com.team_nebula.nebula.domain.keyword.service.KeywordCommandService;
+import com.team_nebula.nebula.domain.link.service.LinkCommandService;
+import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
+import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
+import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
+import com.team_nebula.nebula.domain.star.entity.Star;
+import com.team_nebula.nebula.domain.star.repository.StarRepository;
+import com.team_nebula.nebula.domain.user.entity.UserNode;
+import com.team_nebula.nebula.domain.user.repository.neo4j.UserNodeRepository;
+import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
+import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StarCommandServiceImpl implements StarCommandService {
+
+    private final StarRepository starRepository;
+    private final UserNodeRepository userNodeRepository;
+    private final CategoryCommandService categoryCommandService;
+    private final KeywordCommandService keywordCommandService;
+    private final LinkCommandService linkCommandService;
+
+    @Override
+    public CreateStarResponseDTO createStar(CreateStarFileDTO requestDTO){
+        CreateStarRequestDTO starRequestDTO = requestDTO.getStarRequestDTO();
+
+        // 유저 인증
+        UserNode userNode = userNodeRepository.findByUserId(starRequestDTO.getUserId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        // 스타 생성 및 유저와 관계 설정
+        Star star = createStarEntity(requestDTO, userNode);
+
+        // 카테고리 관계 설정
+        categoryCommandService.linkStarToCategory(star, starRequestDTO.getCategoryName());
+
+        // 키워드 생성 및 관계 설정
+        keywordCommandService.linkStarToKeywords(star, starRequestDTO.getKeywordList());
+
+        // 스타 간 Link 노드 생성
+        linkCommandService.createLinksForStar(star);
+
+        return CreateStarResponseDTO.builder()
+                .starId(star.getId())
+                .title(star.getTitle())
+                .categoryName(starRequestDTO.getCategoryName())
+                .keywordList(star.getKeywords().stream()
+                        .map(Keyword::getName)
+                        .toList())
+                .build();
+
+    }
+
+    public Star createStarEntity(CreateStarFileDTO requestDTO, UserNode userNode){
+        CreateStarRequestDTO starRequestDTO = requestDTO.getStarRequestDTO();
+
+        Star star = new Star();
+        star.setTitle(starRequestDTO.getTitle());
+        star.setSiteUrl(starRequestDTO.getSiteUrl());
+        star.setThumbnailUrl(s3Service.uploadFile(requestDTO.getThumbnailImage()));
+        star.setHtmlFileUrl(s3Service.uploadFile(requestDTO.getHtmlFile()));
+        star.setSummaryAI(starRequestDTO.getSummaryAI());
+        star.setUserMemo(starRequestDTO.getUserMemo());
+        star.setViews(0);
+        star.setEmbedding(starRequestDTO.getEmbedding());
+
+        Star savedStar = starRepository.save(star);
+        if (savedStar.getId() == null) {
+            throw new GeneralException(ErrorStatus._STAR_CREATION_FAILED);
+        }
+
+        // 유저 노드와 관계 설정 후 저장
+        userNode.getStars().add(savedStar);
+        userNodeRepository.save(userNode);
+
+        return savedStar;
+    }
+
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
@@ -1,9 +1,18 @@
 package com.team_nebula.nebula.domain.star.service;
 
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
+import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.GetStarListResponseDTO;
+import com.team_nebula.nebula.domain.user.entity.UserNode;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 public interface StarQueryService {
 
     public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData);
+
+    public GetStarListResponseDTO getStarList(Long userId);
+
+    public List<GetStarOneResponseDTO> getAllStar(UserNode userNode);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
@@ -1,0 +1,9 @@
+package com.team_nebula.nebula.domain.star.service;
+
+import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StarQueryService {
+
+    public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData);
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
@@ -15,4 +15,6 @@ public interface StarQueryService {
     public GetStarListResponseDTO getStarList(Long userId);
 
     public List<GetStarOneResponseDTO> getAllStar(UserNode userNode);
+
+    public GetStarOneResponseDTO getStarOne(Long starId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -16,6 +16,7 @@ import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -23,6 +24,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StarQueryServiceImpl implements StarQueryService {
 
     private final StarRepository starRepository;
@@ -46,12 +48,12 @@ public class StarQueryServiceImpl implements StarQueryService {
             throw new RuntimeException("Invalid JSON format for starJsonData.");
         }
 
-        CreateStarFileDTO requestDTO = new CreateStarFileDTO();
-        requestDTO.setThumbnailImage(thumbnailImage);
-        requestDTO.setHtmlFile(htmlFile);
-        requestDTO.setStarRequestDTO(request);
+        return CreateStarFileDTO.builder()
+                .thumbnailImage(thumbnailImage)
+                .htmlFile(htmlFile)
+                .starRequestDTO(request)
+                .build();
 
-        return requestDTO;
     }
 
     // 스타 + 링크 전체 조회

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -2,15 +2,13 @@ package com.team_nebula.nebula.domain.star.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
-import com.team_nebula.nebula.domain.keyword.repository.KeywordRepository;
 import com.team_nebula.nebula.domain.link.service.LinkQueryService;
+import com.team_nebula.nebula.domain.star.converter.StarConverter;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetLinkOneResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetStarListResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
-import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.domain.star.repository.StarRepository;
 import com.team_nebula.nebula.domain.user.entity.UserNode;
 import com.team_nebula.nebula.domain.user.repository.neo4j.UserNodeRepository;
@@ -31,6 +29,8 @@ public class StarQueryServiceImpl implements StarQueryService {
     private final UserNodeRepository userNodeRepository;
     private final LinkQueryService linkQueryService;
 
+
+    // 스타 JSON 데이터 파싱
     @Override
     public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData){
 
@@ -54,6 +54,7 @@ public class StarQueryServiceImpl implements StarQueryService {
         return requestDTO;
     }
 
+    // 스타 + 링크 전체 조회
     @Override
     public GetStarListResponseDTO getStarList(Long userId){
 
@@ -75,23 +76,21 @@ public class StarQueryServiceImpl implements StarQueryService {
                 .build();
     }
 
-    @Override
-    public List<GetStarOneResponseDTO> getAllStar(UserNode userNode){
+    // 스타 노드 전체 조회
+    public List<GetStarOneResponseDTO> getAllStar(UserNode userNode) {
         List<Map<String, Object>> starDataList = starRepository.findStarsByUserId(userNode.getUserId());
 
         return starDataList.stream()
-                .map(data -> GetStarOneResponseDTO.builder()
-                        .starId(((Star) data.get("s")).getId())
-                        .categoryName((String) data.get("categoryName"))
-                        .title(((Star) data.get("s")).getTitle())
-                        .siteUrl(((Star) data.get("s")).getSiteUrl())
-                        .thumbnailUrl(((Star) data.get("s")).getThumbnailUrl())
-                        .summaryAI(((Star) data.get("s")).getSummaryAI())
-                        .userMemo(((Star) data.get("s")).getUserMemo())
-                        .views(((Star) data.get("s")).getViews())
-                        .keywordList((List<String>) data.get("keywordList"))
-                        .build())
+                .map(StarConverter::convertToStarOneDto)
                 .toList();
+    }
+
+    // 단일 스타 조회
+    public GetStarOneResponseDTO getStarOne(Long starId) {
+        Map<String, Object> data = starRepository.findStarDetailById(starId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
+
+        return StarConverter.convertToStarOneDto(data);
     }
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -4,13 +4,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
 import com.team_nebula.nebula.domain.keyword.repository.KeywordRepository;
+import com.team_nebula.nebula.domain.link.service.LinkQueryService;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
+import com.team_nebula.nebula.domain.star.dto.response.GetLinkOneResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.GetStarListResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
+import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.domain.star.repository.StarRepository;
+import com.team_nebula.nebula.domain.user.entity.UserNode;
 import com.team_nebula.nebula.domain.user.repository.neo4j.UserNodeRepository;
+import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
+import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -18,8 +29,7 @@ public class StarQueryServiceImpl implements StarQueryService {
 
     private final StarRepository starRepository;
     private final UserNodeRepository userNodeRepository;
-    private final KeywordRepository keywordRepository;
-    private final CategoryRepository categoryRepository;
+    private final LinkQueryService linkQueryService;
 
     @Override
     public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData){
@@ -42,6 +52,46 @@ public class StarQueryServiceImpl implements StarQueryService {
         requestDTO.setStarRequestDTO(request);
 
         return requestDTO;
+    }
+
+    @Override
+    public GetStarListResponseDTO getStarList(Long userId){
+
+        // 유저 인증
+        UserNode userNode = userNodeRepository.findByUserId(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        // 스타 전체 조회
+        List<GetStarOneResponseDTO> stars = getAllStar(userNode);
+
+        // 링크 전체 조회
+        List<GetLinkOneResponseDTO> links = linkQueryService.getAllLink(userNode);
+
+        return GetStarListResponseDTO.builder()
+                .totalStarCnt(stars.size())
+                .totalLinkCnt(links.size())
+                .starListDto(stars)
+                .linkListDto(links)
+                .build();
+    }
+
+    @Override
+    public List<GetStarOneResponseDTO> getAllStar(UserNode userNode){
+        List<Map<String, Object>> starDataList = starRepository.findStarsByUserId(userNode.getUserId());
+
+        return starDataList.stream()
+                .map(data -> GetStarOneResponseDTO.builder()
+                        .starId(((Star) data.get("s")).getId())
+                        .categoryName((String) data.get("categoryName"))
+                        .title(((Star) data.get("s")).getTitle())
+                        .siteUrl(((Star) data.get("s")).getSiteUrl())
+                        .thumbnailUrl(((Star) data.get("s")).getThumbnailUrl())
+                        .summaryAI(((Star) data.get("s")).getSummaryAI())
+                        .userMemo(((Star) data.get("s")).getUserMemo())
+                        .views(((Star) data.get("s")).getViews())
+                        .keywordList((List<String>) data.get("keywordList"))
+                        .build())
+                .toList();
     }
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -1,0 +1,47 @@
+package com.team_nebula.nebula.domain.star.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
+import com.team_nebula.nebula.domain.keyword.repository.KeywordRepository;
+import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
+import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
+import com.team_nebula.nebula.domain.star.repository.StarRepository;
+import com.team_nebula.nebula.domain.user.repository.neo4j.UserNodeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class StarQueryServiceImpl implements StarQueryService {
+
+    private final StarRepository starRepository;
+    private final UserNodeRepository userNodeRepository;
+    private final KeywordRepository keywordRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData){
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        // starJsonData 파싱
+        CreateStarRequestDTO request;
+        try {
+            request = objectMapper.readValue(starJsonData, CreateStarRequestDTO.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Invalid JSON format for starJsonData.");
+        }
+
+        CreateStarFileDTO requestDTO = new CreateStarFileDTO();
+        requestDTO.setThumbnailImage(thumbnailImage);
+        requestDTO.setHtmlFile(htmlFile);
+        requestDTO.setStarRequestDTO(request);
+
+        return requestDTO;
+    }
+
+}

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -26,7 +26,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD4001", "키워드가 존재하지 않습니다."),
 
-	MULTIPARTFILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,"MULTIPARTFILE5000","MultipartFile -> File로 변환이 실패하였습니다.");
+	_MULTIPARTFILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,"MULTIPARTFILE5000","MultipartFile -> File로 변환이 실패하였습니다.");
 
 	private HttpStatus httpStatus;
 	private String code;

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -23,7 +23,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	_STAR_CREATION_FAILED(HttpStatus.CREATED, "STAR5000", "스타 생성에 실패했습니다."),
 
-	_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD4001", "키워드가 존재하지 않습니다.");
+	_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD4001", "키워드가 존재하지 않습니다."),
+
+	MULTIPARTFILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,"MULTIPARTFILE5000","MultipartFile -> File로 변환이 실패하였습니다.");
 
 	private HttpStatus httpStatus;
 	private String code;

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -19,8 +19,11 @@ public enum ErrorStatus implements BaseErrorCode {
 	_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "사용자가 없습니다."),
 
 	_CATEGORY_ALREADY_EXIST(HttpStatus.CONFLICT, "CATEGORY4000", "이미 존재하는 카테고리입니다."),
-	_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4001", "카테고리를 찾을 수 없습니다.");
+	_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4001", "카테고리를 찾을 수 없습니다."),
 
+	_STAR_CREATION_FAILED(HttpStatus.CREATED, "STAR5000", "스타 생성에 실패했습니다."),
+
+	_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD4001", "키워드가 존재하지 않습니다.");
 
 	private HttpStatus httpStatus;
 	private String code;

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	_CATEGORY_ALREADY_EXIST(HttpStatus.CONFLICT, "CATEGORY4000", "이미 존재하는 카테고리입니다."),
 	_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4001", "카테고리를 찾을 수 없습니다."),
 
+	_STAR_NOT_FOUND(HttpStatus.NOT_FOUND, "STAR4001", "해당 스타 정보를 찾을 수 없습니다."),
 	_STAR_CREATION_FAILED(HttpStatus.CREATED, "STAR5000", "스타 생성에 실패했습니다."),
 
 	_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD4001", "키워드가 존재하지 않습니다."),

--- a/src/main/java/com/team_nebula/nebula/global/config/S3Config.java
+++ b/src/main/java/com/team_nebula/nebula/global/config/S3Config.java
@@ -1,0 +1,28 @@
+package com.team_nebula.nebula.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}


### PR DESCRIPTION
## 💡 개요
스타를 생성하는 기능 구현 + 스타 전체 및 단일 조회

## 🔨작업 사항
![image](https://github.com/user-attachments/assets/3909b0dd-869e-494d-b15f-fbcdae71bcf4)
![image](https://github.com/user-attachments/assets/08438f32-118b-4c60-b23f-99f8960e4d2d)
![image](https://github.com/user-attachments/assets/43bdddc9-5dd6-4038-a6ab-829c4d1362b8)
- 섬네일 이미지, html 파일, 그외 필요한 데이터를 JSON형식의 String으로 받아서 파싱한 후에 스타 생성하기로함
- 파일은 JSON 형식으로 넘겨줄수 없기 때문에 위에 형식으로 처리하기로함

![image](https://github.com/user-attachments/assets/1170da49-ab9e-4575-91d5-bebffaa29c83)
- 유저인증-> 스타생성- > 스타-유저 관계 설정 -> 스타-카테고리 관계설정 -> 키워드 생성 및 관계설정 -> 링크 설정 순으로 서비스단을 나눠서 구현함
- 하나의 서비스단에 넣으면 너무너무 길어짐

![image](https://github.com/user-attachments/assets/ab857167-15ad-4275-832b-3612f517c9b2)
- Cypher 쿼리 전체 흐름은 Star → 공통 Keyword 찾기 → Link 생성순임
- MERGE를 활용하여 중복 방지함
- 공통 키워드 개수를 기반으로 Link를 동적으로 생성
- similarityScore 계산은 추후에 AI기능이 구현되면 더 구체화할 예정임. 지금은 임의값 넣는 것으로 대체함

---

![image](https://github.com/user-attachments/assets/07301109-443c-4e91-8797-37cf0d30f05d)
![image](https://github.com/user-attachments/assets/65b4b103-aeb9-4c9e-bf01-ac5a9ff1771f)
![image](https://github.com/user-attachments/assets/9d6aed80-76a1-4908-b327-506068360cd4)
- DTO를 나눠서 스타, 링크 데이터를 따로따로 나눠서 전달함
- 나중에 프론트랑 협의해서 더 좋은 전달 방식이 있으면 수정할 예정


## 📝 기타 (선택)
테스트를 아직 못해봐서 에러가 많이 무섭지만 전체적인 흐름은 거의 비슷할 예정. 신경써야할 부분이 많아서 혹시 서비스상 빠진 부분이 있으면 피드백 부탁드립니다~!
