### PR TITLE
scrum 130 : 키워드별, 카테고리별 스타 조회 기능 구현

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -45,4 +45,17 @@ public interface LinkRepository extends Neo4jRepository<Link, Long> {
     """)
     List<Map<String, Object>> findLinkInCategory(@Param("userId") Long userId, @Param("categoryId") Long categoryId);
 
+    @Query("""
+    MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:TAGGED]->(k:Keyword)
+    WHERE u.userId = $userId AND k.keywordId = $keywordId
+    
+    MATCH (s)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
+    WHERE (u)-[:CREATED]->(s2)
+    
+    RETURN l, 
+           l.linked_two_node_Id AS linkedNodeIdList, 
+           l.sharedKeywordNum AS sharedKeywordNum, 
+           l.similarityScore AS similarity
+    """)
+    List<Map<String, Object>> findLinkInKeyword(@Param("userId") Long userId, @Param("keywordId") Long keywordId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -30,4 +30,19 @@ public interface LinkRepository extends Neo4jRepository<Link, Long> {
                l.similarityScore AS similarity
     """)
     List<Map<String, Object>> findLinksByUserId(@Param("userId") Long userId);
+
+    @Query("""
+    MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:BELONGS_TO]->(c:Category)
+    WHERE u.userId = $userId AND c.categoryId = $categoryId
+    
+    MATCH (s)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
+    WHERE (u)-[:CREATED]->(s2)
+    
+    RETURN l, 
+           l.linked_two_node_Id AS linkedNodeIdList, 
+           l.sharedKeywordNum AS sharedKeywordNum, 
+           l.similarityScore AS similarity
+    """)
+    List<Map<String, Object>> findLinkInCategory(@Param("userId") Long userId, @Param("categoryId") Long categoryId);
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryService.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface LinkQueryService {
     public List<GetLinkOneResponseDTO> getAllLink(UserNode userNode);
+
+    public List<GetLinkOneResponseDTO> getLinkInCategory(Long userId, Long categoryId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryService.java
@@ -9,4 +9,7 @@ public interface LinkQueryService {
     public List<GetLinkOneResponseDTO> getAllLink(UserNode userNode);
 
     public List<GetLinkOneResponseDTO> getLinkInCategory(Long userId, Long categoryId);
+
+    public List<GetLinkOneResponseDTO> getLinkInKeyword(Long userId, Long keywordId);
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
@@ -34,6 +34,7 @@ public class LinkQueryServiceImpl implements LinkQueryService {
 
     }
 
+    // 카테고리별 링크 노드 조회
     @Override
     public List<GetLinkOneResponseDTO> getLinkInCategory(Long userId, Long categoryId){
         List<Map<String, Object>> linkDataList = linkRepository.findLinkInCategory(userId, categoryId);
@@ -47,5 +48,21 @@ public class LinkQueryServiceImpl implements LinkQueryService {
                         .build())
                 .toList();
     }
+
+    // 키워드별 링크 노드 조회
+    @Override
+    public List<GetLinkOneResponseDTO> getLinkInKeyword(Long userId, Long keywordId){
+        List<Map<String, Object>> linkDataList = linkRepository.findLinkInKeyword(userId, keywordId);
+
+        return linkDataList.stream()
+                .map(data -> GetLinkOneResponseDTO.builder()
+                        .linkId(((Link) data.get("l")).getId())
+                        .sharedKeywordNum((int) data.get("sharedKeywordNum"))
+                        .similarity((double) data.get("similarity"))
+                        .linkedNodeIdList((List<Long>) data.get("linkedNodeIdList"))
+                        .build())
+                .toList();
+    }
+
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
@@ -33,4 +33,19 @@ public class LinkQueryServiceImpl implements LinkQueryService {
                 .toList();
 
     }
+
+    @Override
+    public List<GetLinkOneResponseDTO> getLinkInCategory(Long userId, Long categoryId){
+        List<Map<String, Object>> linkDataList = linkRepository.findLinkInCategory(userId, categoryId);
+
+        return linkDataList.stream()
+                .map(data -> GetLinkOneResponseDTO.builder()
+                        .linkId(((Link) data.get("l")).getId())
+                        .sharedKeywordNum((int) data.get("sharedKeywordNum"))
+                        .similarity((double) data.get("similarity"))
+                        .linkedNodeIdList((List<Long>) data.get("linkedNodeIdList"))
+                        .build())
+                .toList();
+    }
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -30,6 +30,7 @@ public class StarController {
         CreateStarFileDTO requestDTO = starQueryService.starDataParsing(thumbnailImage, htmlFile, starJsonData);
 
         CreateStarResponseDTO responseDTO = starCommandService.createStar(requestDTO);
+
         return ApiResponse.onSuccessCreated(responseDTO);
     }
 
@@ -43,6 +44,13 @@ public class StarController {
     @GetMapping("/{starId}")
     public ApiResponse<GetStarOneResponseDTO> getStarOne(@PathVariable Long starId){
         GetStarOneResponseDTO responseDTO = starQueryService.getStarOne(starId);
+
+        return ApiResponse.onSuccess(responseDTO);
+    }
+
+    @GetMapping("/{userId}/{categoryId}")
+    public ApiResponse<GetStarListResponseDTO> getStarListByCategory(@PathVariable Long userId, Long categoryId){
+        GetStarListResponseDTO responseDTO = starQueryService.getStarListInCategory(userId, categoryId);
 
         return ApiResponse.onSuccess(responseDTO);
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -49,8 +49,15 @@ public class StarController {
     }
 
     @GetMapping("/{userId}/{categoryId}")
-    public ApiResponse<GetStarListResponseDTO> getStarListByCategory(@PathVariable Long userId, Long categoryId){
+    public ApiResponse<GetStarListResponseDTO> getStarListByCategory(@PathVariable Long userId, @PathVariable Long categoryId){
         GetStarListResponseDTO responseDTO = starQueryService.getStarListInCategory(userId, categoryId);
+
+        return ApiResponse.onSuccess(responseDTO);
+    }
+
+    @GetMapping("/{userId}/{keywordId}")
+    public ApiResponse<GetStarListResponseDTO> getStarListByKeyword(@PathVariable Long userId, @PathVariable Long keywordId){
+        GetStarListResponseDTO responseDTO = starQueryService.getStarListInKeyword(userId, keywordId);
 
         return ApiResponse.onSuccess(responseDTO);
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -21,6 +21,7 @@ public class StarController {
     private final StarCommandService starCommandService;
     private final StarQueryService starQueryService;
 
+    // 스타 생성 API
     @PostMapping("")
     public ApiResponse<CreateStarResponseDTO> createStar(
             @RequestPart(value = "thumbnailImage",required = false) MultipartFile thumbnailImage,
@@ -34,6 +35,7 @@ public class StarController {
         return ApiResponse.onSuccessCreated(responseDTO);
     }
 
+    // 스타 전체 조회 API
     @GetMapping("/{userId}")
     public ApiResponse<GetStarListResponseDTO> getStarList(@PathVariable Long userId){
         GetStarListResponseDTO responseDTO = starQueryService.getStarList(userId);
@@ -41,6 +43,7 @@ public class StarController {
         return ApiResponse.onSuccess(responseDTO);
     }
 
+    // 스타 단일 조회 API
     @GetMapping("/{starId}")
     public ApiResponse<GetStarOneResponseDTO> getStarOne(@PathVariable Long starId){
         GetStarOneResponseDTO responseDTO = starQueryService.getStarOne(starId);
@@ -48,6 +51,7 @@ public class StarController {
         return ApiResponse.onSuccess(responseDTO);
     }
 
+    // 카테고리별 스타 조회 API
     @GetMapping("/{userId}/{categoryId}")
     public ApiResponse<GetStarListResponseDTO> getStarListByCategory(@PathVariable Long userId, @PathVariable Long categoryId){
         GetStarListResponseDTO responseDTO = starQueryService.getStarListInCategory(userId, categoryId);
@@ -55,6 +59,7 @@ public class StarController {
         return ApiResponse.onSuccess(responseDTO);
     }
 
+    // 키워드별 스타 조회 API
     @GetMapping("/{userId}/{keywordId}")
     public ApiResponse<GetStarListResponseDTO> getStarListByKeyword(@PathVariable Long userId, @PathVariable Long keywordId){
         GetStarListResponseDTO responseDTO = starQueryService.getStarListInKeyword(userId, keywordId);

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetStarListResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetStarListResponseDTO.java
@@ -12,6 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GetStarListResponseDTO {
+    private String type;
     private int totalStarCnt;
     private int totalLinkCnt;
     private List<GetStarOneResponseDTO> starListDto;

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
@@ -28,4 +28,14 @@ public interface StarRepository extends Neo4jRepository<Star, Long> {
         RETURN s AS s, c.name AS categoryName, COLLECT(k.name) AS keywordList
     """)
     Optional<Map<String, Object>> findStarDetailById(@Param("starId") Long starId);
+
+    @Query("""
+    MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:BELONGS_TO]->(c:Category)
+    WHERE u.userId = $userId AND c.categoryId = $categoryId
+    OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
+    RETURN s, 
+           c.name AS categoryName, 
+           COLLECT(k.name) AS keywordList
+    """)
+    List<Map<String, Object>> findStarsInCategory(@Param("userId") Long userId, @Param("categoryId") Long categoryId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
@@ -38,4 +38,14 @@ public interface StarRepository extends Neo4jRepository<Star, Long> {
            COLLECT(k.name) AS keywordList
     """)
     List<Map<String, Object>> findStarsInCategory(@Param("userId") Long userId, @Param("categoryId") Long categoryId);
+
+    @Query("""
+    MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:TAGGED]->(k:Keyword)
+    WHERE u.userId = $userId AND k.keywordId = $keywordId
+    OPTIONAL MATCH (s)-[:BELONGS_TO]->(c:Category)
+    RETURN s, 
+           c.name AS categoryName, 
+           COLLECT(k.name) AS keywordList
+    """)
+    List<Map<String, Object>> findStarsInKeyword(@Param("userId") Long userId, @Param("keywordId") Long keywordId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
@@ -17,4 +17,6 @@ public interface StarQueryService {
     public List<GetStarOneResponseDTO> getAllStar(UserNode userNode);
 
     public GetStarOneResponseDTO getStarOne(Long starId);
+
+    public GetStarListResponseDTO getStarListInCategory(Long userId, Long categoryId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
@@ -14,11 +14,16 @@ public interface StarQueryService {
 
     public GetStarListResponseDTO getStarList(Long userId);
 
-    public List<GetStarOneResponseDTO> getAllStar(UserNode userNode);
+    public List<GetStarOneResponseDTO> findAllStar(UserNode userNode);
 
     public GetStarOneResponseDTO getStarOne(Long starId);
 
     public GetStarListResponseDTO getStarListInCategory(Long userId, Long categoryId);
 
+    public List<GetStarOneResponseDTO> findStarInCategory(Long userId, Long categoryId);
+
     public GetStarListResponseDTO getStarListInKeyword(Long userId, Long keywordId);
+
+    public List<GetStarOneResponseDTO> findStarInKeyword(Long userId, Long keywordId);
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
@@ -19,4 +19,6 @@ public interface StarQueryService {
     public GetStarOneResponseDTO getStarOne(Long starId);
 
     public GetStarListResponseDTO getStarListInCategory(Long userId, Long categoryId);
+
+    public GetStarListResponseDTO getStarListInKeyword(Long userId, Long keywordId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -22,7 +22,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -32,8 +31,6 @@ public class StarQueryServiceImpl implements StarQueryService {
     private final StarRepository starRepository;
     private final UserNodeRepository userNodeRepository;
     private final LinkQueryService linkQueryService;
-    private final CategoryRepository categoryRepository;
-
 
     // 스타 JSON 데이터 파싱
     @Override
@@ -68,7 +65,7 @@ public class StarQueryServiceImpl implements StarQueryService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
         // 스타 전체 조회
-        List<GetStarOneResponseDTO> stars = getAllStar(userNode);
+        List<GetStarOneResponseDTO> stars = findAllStar(userNode);
 
         // 링크 전체 조회
         List<GetLinkOneResponseDTO> links = linkQueryService.getAllLink(userNode);
@@ -83,7 +80,8 @@ public class StarQueryServiceImpl implements StarQueryService {
     }
 
     // 스타 노드 전체 조회
-    public List<GetStarOneResponseDTO> getAllStar(UserNode userNode) {
+    @Override
+    public List<GetStarOneResponseDTO> findAllStar(UserNode userNode) {
         List<Map<String, Object>> starDataList = starRepository.findStarsByUserId(userNode.getUserId());
 
         return starDataList.stream()
@@ -92,6 +90,7 @@ public class StarQueryServiceImpl implements StarQueryService {
     }
 
     // 단일 스타 조회
+    @Override
     public GetStarOneResponseDTO getStarOne(Long starId) {
         Map<String, Object> data = starRepository.findStarDetailById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
@@ -107,7 +106,7 @@ public class StarQueryServiceImpl implements StarQueryService {
         UserNode userNode = userNodeRepository.findByUserId(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-        List<GetStarOneResponseDTO> starsInCategory = getStarInCategory(userId, categoryId);
+        List<GetStarOneResponseDTO> starsInCategory = findStarInCategory(userId, categoryId);
         List<GetLinkOneResponseDTO> linksInCategory = linkQueryService.getLinkInCategory(userId, categoryId);
 
         return GetStarListResponseDTO.builder()
@@ -119,7 +118,8 @@ public class StarQueryServiceImpl implements StarQueryService {
                 .build();
     }
 
-    public List<GetStarOneResponseDTO> getStarInCategory(Long userId, Long categoryId) {
+    @Override
+    public List<GetStarOneResponseDTO> findStarInCategory(Long userId, Long categoryId) {
         List<Map<String, Object>> starDataList = starRepository.findStarsInCategory(userId, categoryId);
 
         return starDataList.stream()
@@ -133,7 +133,7 @@ public class StarQueryServiceImpl implements StarQueryService {
         UserNode userNode = userNodeRepository.findByUserId(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-        List<GetStarOneResponseDTO> starsInCategory = getStarInKeyword(userId, keywordId);
+        List<GetStarOneResponseDTO> starsInCategory = findStarInKeyword(userId, keywordId);
         List<GetLinkOneResponseDTO> linksInCategory = linkQueryService.getLinkInKeyword(userId, keywordId);
 
         return GetStarListResponseDTO.builder()
@@ -145,7 +145,8 @@ public class StarQueryServiceImpl implements StarQueryService {
                 .build();
     }
 
-    public List<GetStarOneResponseDTO> getStarInKeyword(Long userId, Long keywordId) {
+    @Override
+    public List<GetStarOneResponseDTO> findStarInKeyword(Long userId, Long keywordId) {
         List<Map<String, Object>> starDataList = starRepository.findStarsInKeyword(userId, keywordId);
 
         return starDataList.stream()

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -2,7 +2,6 @@ package com.team_nebula.nebula.domain.star.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.team_nebula.nebula.domain.category.entity.Category;
 import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
 import com.team_nebula.nebula.domain.link.service.LinkQueryService;
 import com.team_nebula.nebula.domain.star.converter.StarConverter;
@@ -108,7 +107,7 @@ public class StarQueryServiceImpl implements StarQueryService {
         UserNode userNode = userNodeRepository.findByUserId(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-        List<GetStarOneResponseDTO> starsInCategory = getStarinCategory(userId, categoryId);
+        List<GetStarOneResponseDTO> starsInCategory = getStarInCategory(userId, categoryId);
         List<GetLinkOneResponseDTO> linksInCategory = linkQueryService.getLinkInCategory(userId, categoryId);
 
         return GetStarListResponseDTO.builder()
@@ -120,12 +119,38 @@ public class StarQueryServiceImpl implements StarQueryService {
                 .build();
     }
 
-
-    public List<GetStarOneResponseDTO> getStarinCategory(Long userId, Long categoryId) {
+    public List<GetStarOneResponseDTO> getStarInCategory(Long userId, Long categoryId) {
         List<Map<String, Object>> starDataList = starRepository.findStarsInCategory(userId, categoryId);
 
         return starDataList.stream()
                 .map(StarConverter::convertToStarOneDto)
                 .toList();
     }
+
+    @Override
+    public GetStarListResponseDTO getStarListInKeyword(Long userId, Long keywordId){
+        // 유저 인증
+        UserNode userNode = userNodeRepository.findByUserId(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        List<GetStarOneResponseDTO> starsInCategory = getStarInKeyword(userId, keywordId);
+        List<GetLinkOneResponseDTO> linksInCategory = linkQueryService.getLinkInKeyword(userId, keywordId);
+
+        return GetStarListResponseDTO.builder()
+                .type("Keyword")
+                .totalStarCnt(starsInCategory.size())
+                .totalLinkCnt(linksInCategory.size())
+                .starListDto(starsInCategory)
+                .linkListDto(linksInCategory)
+                .build();
+    }
+
+    public List<GetStarOneResponseDTO> getStarInKeyword(Long userId, Long keywordId) {
+        List<Map<String, Object>> starDataList = starRepository.findStarsInKeyword(userId, keywordId);
+
+        return starDataList.stream()
+                .map(StarConverter::convertToStarOneDto)
+                .toList();
+    }
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -2,6 +2,8 @@ package com.team_nebula.nebula.domain.star.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.team_nebula.nebula.domain.category.entity.Category;
+import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
 import com.team_nebula.nebula.domain.link.service.LinkQueryService;
 import com.team_nebula.nebula.domain.star.converter.StarConverter;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
@@ -21,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +33,7 @@ public class StarQueryServiceImpl implements StarQueryService {
     private final StarRepository starRepository;
     private final UserNodeRepository userNodeRepository;
     private final LinkQueryService linkQueryService;
+    private final CategoryRepository categoryRepository;
 
 
     // 스타 JSON 데이터 파싱
@@ -71,6 +75,7 @@ public class StarQueryServiceImpl implements StarQueryService {
         List<GetLinkOneResponseDTO> links = linkQueryService.getAllLink(userNode);
 
         return GetStarListResponseDTO.builder()
+                .type("ALL")
                 .totalStarCnt(stars.size())
                 .totalLinkCnt(links.size())
                 .starListDto(stars)
@@ -95,4 +100,32 @@ public class StarQueryServiceImpl implements StarQueryService {
         return StarConverter.convertToStarOneDto(data);
     }
 
+    // 카테고리별 스타 조회
+    @Override
+    public GetStarListResponseDTO getStarListInCategory(Long userId, Long categoryId){
+
+        // 유저 인증
+        UserNode userNode = userNodeRepository.findByUserId(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        List<GetStarOneResponseDTO> starsInCategory = getStarinCategory(userId, categoryId);
+        List<GetLinkOneResponseDTO> linksInCategory = linkQueryService.getLinkInCategory(userId, categoryId);
+
+        return GetStarListResponseDTO.builder()
+                .type("Category")
+                .totalStarCnt(starsInCategory.size())
+                .totalLinkCnt(linksInCategory.size())
+                .starListDto(starsInCategory)
+                .linkListDto(linksInCategory)
+                .build();
+    }
+
+
+    public List<GetStarOneResponseDTO> getStarinCategory(Long userId, Long categoryId) {
+        List<Map<String, Object>> starDataList = starRepository.findStarsInCategory(userId, categoryId);
+
+        return starDataList.stream()
+                .map(StarConverter::convertToStarOneDto)
+                .toList();
+    }
 }


### PR DESCRIPTION
## 💡 개요
키워드별, 카테고리별 스타 조회 기능 구현

## 🔨작업 사항
![image](https://github.com/user-attachments/assets/52183e99-2461-4632-8d96-6d4c7dc7a0f6)
- 기존 스타 전체 조회에서 사용하던 DTO에 type 필드를 추가해서 재사용함
- type 필드는 솔직히 없어도 잘 돌아가지만 무슨 조건으로 스타를 구분했는지 알기위해 추가함

![image](https://github.com/user-attachments/assets/a9f4c1ce-d301-4c23-9f9f-1533c854c954)
![image](https://github.com/user-attachments/assets/a72a75a0-ff2a-47c0-858a-01f1c6893676)
- 작동방식은 스타 전체 조회랑 거의 유사함
- Repository에서 쿼리 조건만 달라짐

## 📝 기타 (선택)
다른 기능도 달려보겠습니다!