### PR TITLE
SCRUM 140 : 카테고리 API 에러 수정

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -57,11 +57,11 @@ jobs:
           EC2_USER: ${{ secrets.LOCAL_EC2_USERNAME }}
           EC2_SSH_KEY: ${{ secrets.LOCAL_SSH_PRIVATE_KEY }}
           EC2_PORT: ${{ secrets.LOCAL_EC2_PORT }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
         run: |
           ssh -p $EC2_PORT -i ec2_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST '
             # 명령어 실행
-            sudo docker pull $DOCKER_USERNAME/nebula
+            sudo docker pull $DOCKER_REPO
             container_id=$(docker ps -aq --filter "name=nubula")
             if [ -n "$container_id" ]; then
               echo "컨테이너 존재, 중지"
@@ -70,6 +70,6 @@ jobs:
             else
               echo "컨테이너 없음"
             fi
-              docker run -d -p 8080:8080 --name nubula $DOCKER_USERNAME/nubula
+              docker run -d -p 8080:8080 --name nubula $DOCKER_REPO
           '
           

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -62,11 +62,14 @@ jobs:
           ssh -p $EC2_PORT -i ec2_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST '
             # 명령어 실행
             sudo docker pull $DOCKER_USERNAME/nebula
-            sudo docker stop nebula 2>/dev/null || true
-            sudo docker rm nebula 2>/dev/null || true
-            sudo docker run -d \
-              --name nebula \
-              -p 8080:8080 \
-              $DOCKER_USERNAME/nebula:latest
+            container_id=$(docker ps -aq --filter "name=nubula")
+            if [ -n "$container_id" ]; then
+              echo "컨테이너 존재, 중지"
+              sudo docker stop $container_id
+              sudo docker rm $container_id
+            else
+              echo "컨테이너 없음"
+            fi
+              docker run -d -p 8080:8080 --name nubula $DOCKER_USERNAME/nubula
           '
           

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -57,11 +57,10 @@ jobs:
           EC2_USER: ${{ secrets.LOCAL_EC2_USERNAME }}
           EC2_SSH_KEY: ${{ secrets.LOCAL_SSH_PRIVATE_KEY }}
           EC2_PORT: ${{ secrets.LOCAL_EC2_PORT }}
-          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
         run: |
           ssh -p $EC2_PORT -i ec2_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST '
             # 명령어 실행
-            sudo docker pull $DOCKER_REPO
+            sudo docker pull ${{ secrets.DOCKER_REPO }}
             container_id=$(docker ps -aq --filter "name=nubula")
             if [ -n "$container_id" ]; then
               echo "컨테이너 존재, 중지"
@@ -70,6 +69,6 @@ jobs:
             else
               echo "컨테이너 없음"
             fi
-              docker run -d -p 8080:8080 --name nubula $DOCKER_REPO
+              docker run -d -p 8080:8080 --name nubula ${{ secrets.DOCKER_REPO }}
           '
           

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/team_nebula/nebula/domain/category/api/CategoryController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/api/CategoryController.java
@@ -9,13 +9,14 @@ import com.team_nebula.nebula.domain.user.entity.User;
 import com.team_nebula.nebula.global.annotation.AuthUser;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "[카테고리]")
-@RequestMapping("/api/v1/bookmarks/categories")
+@RequestMapping("/api/v1/stars/categories")
 public class CategoryController {
 
     private final CategoryCommandService categoryCommandService;
@@ -24,7 +25,7 @@ public class CategoryController {
     // 카데고리 생성 API
     @PostMapping
     public ApiResponse<CreateCategoryResponseDTO> createCategory(@AuthUser User user,
-        @RequestBody CreateCategoryRequestDTO request) {
+        @RequestBody @Valid CreateCategoryRequestDTO request) {
         CreateCategoryResponseDTO responseDto = categoryCommandService.createCategory(request, user.getId());
         return ApiResponse.onSuccessCreated(responseDto);
     }

--- a/src/main/java/com/team_nebula/nebula/domain/category/dto/request/CreateCategoryRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/dto/request/CreateCategoryRequestDTO.java
@@ -2,6 +2,7 @@ package com.team_nebula.nebula.domain.category.dto.request;
 
 import lombok.Getter;
 
+
 @Getter
 public class CreateCategoryRequestDTO {
     private String name;

--- a/src/main/java/com/team_nebula/nebula/domain/category/dto/response/CreateCategoryResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/dto/response/CreateCategoryResponseDTO.java
@@ -1,5 +1,6 @@
 package com.team_nebula.nebula.domain.category.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +16,9 @@ import java.util.UUID;
 public class CreateCategoryResponseDTO {
     private UUID categoryId;
     private String name;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/category/dto/response/CreateCategoryResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/dto/response/CreateCategoryResponseDTO.java
@@ -6,13 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class CreateCategoryResponseDTO {
-    private Long categoryId;
+    private UUID categoryId;
     private String name;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/team_nebula/nebula/domain/category/dto/response/GetCategoryOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/dto/response/GetCategoryOneResponseDTO.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GetCategoryOneResponseDTO {
-    private Long id;
+    private String id;
     private String name;
     private int includedStarCnt;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/category/dto/response/GetCategoryOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/dto/response/GetCategoryOneResponseDTO.java
@@ -5,12 +5,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
+
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class GetCategoryOneResponseDTO {
-    private String id;
+    private UUID id;
     private String name;
     private int includedStarCnt;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/category/entity/Category.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/entity/Category.java
@@ -2,23 +2,24 @@ package com.team_nebula.nebula.domain.category.entity;
 
 import com.team_nebula.nebula.domain.common.BaseEntity;
 import com.team_nebula.nebula.domain.star.entity.Star;
-import jakarta.persistence.GeneratedValue;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Property;
 import org.springframework.data.neo4j.core.schema.Relationship;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 @Node
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category extends BaseEntity {
     @Id
-    @GeneratedValue
-    private Long id;
+    private UUID id;
 
+    @Property(name = "name")
     private String name;
 
     @Relationship(type = "BELONGS_TO", direction = Relationship.Direction.INCOMING)
@@ -26,6 +27,7 @@ public class Category extends BaseEntity {
 
     @Builder
     public Category(String name) {
+        this.id = UUID.randomUUID();
         this.name = name;
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
@@ -8,8 +8,10 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
-public interface CategoryRepository extends Neo4jRepository<Category, Long> {
+public interface CategoryRepository extends Neo4jRepository<Category, UUID> {
+
     boolean existsByName(String name);
 
     @Query("""

--- a/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
@@ -1,12 +1,12 @@
 package com.team_nebula.nebula.domain.category.repository;
 
+import com.team_nebula.nebula.domain.category.dto.response.GetCategoryOneResponseDTO;
 import com.team_nebula.nebula.domain.category.entity.Category;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.query.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -19,7 +19,7 @@ public interface CategoryRepository extends Neo4jRepository<Category, UUID> {
     OPTIONAL MATCH (c)<-[:BELONGS_TO]-(s:Star)
     RETURN c.id AS id, c.name AS name, COUNT(s) AS includedStarCnt
     """)
-    List<Map<String, Object>> findUserCategoriesWithStarCount(@Param("userId") Long userId);
+    List<GetCategoryOneResponseDTO> findUserCategoriesWithStarCount(@Param("userId") Long userId);
 
     Optional<Category> findByName(String name);
 

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
@@ -42,7 +42,6 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
 
         // 유저->카테고리 관계 연결
         userNode.getCategorySet().add(category);
-        System.out.println("관계 설정 여부" + userNode.getCategorySet().size());
         userNodeRepository.save(userNode);
 
         return CreateCategoryResponseDTO.builder()

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
@@ -40,13 +40,10 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
                 .build();
         categoryRepository.save(category);
 
-        System.out.println("------------ 관계 설정 시작 -------------");
         // 유저->카테고리 관계 연결
         userNode.getCategorySet().add(category);
         System.out.println("관계 설정 여부" + userNode.getCategorySet().size());
         userNodeRepository.save(userNode);
-        System.out.println("------------ 관계 설정 끝 -------------");
-
 
         return CreateCategoryResponseDTO.builder()
                 .categoryId(category.getId())

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
@@ -25,7 +25,6 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
     @Override
     public CreateCategoryResponseDTO createCategory(CreateCategoryRequestDTO request, Long userId) {
 
-        // userId 임시 인증 -> 추후에 JWT 유저 인증으로 수정할 계획
         UserNode userNode = userNodeRepository.findByUserId(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
@@ -41,9 +40,13 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
                 .build();
         categoryRepository.save(category);
 
+        System.out.println("------------ 관계 설정 시작 -------------");
         // 유저->카테고리 관계 연결
         userNode.getCategorySet().add(category);
+        System.out.println("관계 설정 여부" + userNode.getCategorySet().size());
         userNodeRepository.save(userNode);
+        System.out.println("------------ 관계 설정 끝 -------------");
+
 
         return CreateCategoryResponseDTO.builder()
                 .categoryId(category.getId())

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryQueryServiceImpl.java
@@ -30,7 +30,7 @@ public class CategoryQueryServiceImpl implements CategoryQueryService {
 
         List<GetCategoryOneResponseDTO> categroyList = categoryData.stream()
                 .map(data -> GetCategoryOneResponseDTO.builder()
-                        .id((Long) data.get("id"))
+                        .id((String) data.get("id"))
                         .name((String) data.get("name"))
                         .includedStarCnt(((Number) data.get("includedStarCnt")).intValue())
                         .build())

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryQueryServiceImpl.java
@@ -3,14 +3,11 @@ package com.team_nebula.nebula.domain.category.service;
 import com.team_nebula.nebula.domain.category.dto.response.GetCategoryListResponseDTO;
 import com.team_nebula.nebula.domain.category.dto.response.GetCategoryOneResponseDTO;
 import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
-import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
-import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -22,23 +19,11 @@ public class CategoryQueryServiceImpl implements CategoryQueryService {
     @Override
     public GetCategoryListResponseDTO getCategoryList(Long userId) {
 
-        List<Map<String, Object>> categoryData = categoryRepository.findUserCategoriesWithStarCount(userId);
-
-        if (categoryData.isEmpty()) {
-            throw new GeneralException(ErrorStatus._CATEGORY_NOT_FOUND);
-        }
-
-        List<GetCategoryOneResponseDTO> categroyList = categoryData.stream()
-                .map(data -> GetCategoryOneResponseDTO.builder()
-                        .id((String) data.get("id"))
-                        .name((String) data.get("name"))
-                        .includedStarCnt(((Number) data.get("includedStarCnt")).intValue())
-                        .build())
-                .toList();
+        List<GetCategoryOneResponseDTO> categoryList = categoryRepository.findUserCategoriesWithStarCount(userId);
 
         return GetCategoryListResponseDTO.builder()
-                .totalCount(categroyList.size())
-                .categoryList(categroyList)
+                .totalCount(categoryList.size())
+                .categoryList(categoryList)
                 .build();
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/common/BaseEntity.java
+++ b/src/main/java/com/team_nebula/nebula/domain/common/BaseEntity.java
@@ -1,5 +1,6 @@
 package com.team_nebula.nebula.domain.common;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;


### PR DESCRIPTION
## 💡 개요
카테고리 생성 및 전체조회 실행 시 발생하는 오류 수정

## 🔨작업 사항
### 1. 카테고리 생성
- 사실 스웨거에서 잘못 입력해서 시간을 많이 날림
- 처음에 스웨거 Request Body에 있는 형식 그대로 적으면 안됌. 그냥 name 하나만 보내주면 정상적으로 작동함
![image](https://github.com/user-attachments/assets/32d459d6-0420-4e8b-8d59-5f35bda10a91)
- Neo4j는 노드 생성시 내부 id가 기본적으로 생기는데 이걸 getId()처럼 사용할 수 없고 또 이게 재사용된다고 함
- 그래서 id 타입을 UUID로 잡아서 카테고리 노드 생성시 자동으로 id를 만들어서 보안을 강화함. 아래 사진처럼 생성됨
- createdAt, updatedAt Response에서 리스트로 반환하는게 Neo4j에서 LocalDateTime을 배열 형태로 저장해서 리스트 형식으로 출력됨. 그래서 DTO에서 JsonFormat을 통해 출력 형식을 지정함
![image](https://github.com/user-attachments/assets/7f6e8bd6-164d-4a38-aa66-ab7834afe51f)
![image](https://github.com/user-attachments/assets/68f74ff2-f05f-41e0-94eb-f15c737cbea0)
![image](https://github.com/user-attachments/assets/ea8055d1-5765-40a1-b3ca-bafec3c6d0b8)


### 2. 카테고리 전체조회
![image](https://github.com/user-attachments/assets/ee2760c5-f39c-4f30-a3fe-80eea2fbcb57)
- 처음에는 Map<String, Object> 타입으로 쿼리 결과를 받을려고 했지만 이 타입으로 쿼리 결과를 변환할 수 없다는 오류가 생김
- 그래서 매핑을 위한 Projection  인터페이스로 받으려고 했지만 이러면 노드에 없는 필드는 매핑할 수 없음
- 돌고 돌아 그냥 DTO 자체로 받으니까 정상적으로 돌아감ㅎ
![image](https://github.com/user-attachments/assets/b3ebcac9-7f73-49e0-9dba-da50a0fdbc53)



## 📝 기타 (선택)
- 너무 돌고 돌아서 수정한 느낌이 많이 들지만 스타 기능 에러 수정할때는 오늘 경험한 것을 바탕으로 하면 잘 될듯함
- Neo4j Aura에서 Query 칸에서 MATCH (n) return n; 을 입력하면 모든 노드만 반환되고 관계는 안나옴
- MATCH (n)-[r]->(m) RETURN n, r, m; 을 입력하면 노드와 관계 모두 나옴 참고하시길