### PR TITLE
SCRUM 141 : 스타 생성 API 에러 수정

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/image/S3Service.java
+++ b/src/main/java/com/team_nebula/nebula/domain/image/S3Service.java
@@ -51,8 +51,8 @@ public class S3Service {
     }
 
     private String putS3(File uploadFile, String fileName) {
-        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
-                .withCannedAcl(CannedAccessControlList.PublicRead));
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile));
+
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }
 

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/entity/Keyword.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/entity/Keyword.java
@@ -1,7 +1,6 @@
 package com.team_nebula.nebula.domain.keyword.entity;
 
 import com.team_nebula.nebula.domain.common.BaseEntity;
-import jakarta.persistence.GeneratedValue;
 import lombok.*;
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
@@ -10,10 +9,8 @@ import org.springframework.data.neo4j.core.schema.Node;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Keyword extends BaseEntity {
-    @Id
-    @GeneratedValue
-    private Long id;
 
+    @Id
     private String name;
 
     @Builder

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -1,11 +1,13 @@
 package com.team_nebula.nebula.domain.keyword.repository;
 
 import com.team_nebula.nebula.domain.keyword.entity.Keyword;
+import com.team_nebula.nebula.domain.star.entity.Star;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.query.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface KeywordRepository extends Neo4jRepository<Keyword, Long> {
     @Query("""
@@ -14,6 +16,7 @@ public interface KeywordRepository extends Neo4jRepository<Keyword, Long> {
         WITH k
         MATCH (s:Star {id: $starId})
         MERGE (s)-[:TAGGED]->(k)
+        RETURN s
     """)
-    void linkStarToKeywords(@Param("starId") Long starId, @Param("keywordNames") List<String> keywordNames);
+    Star linkStarToKeywords(@Param("starId") UUID starId, @Param("keywordNames") List<String> keywordNames);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -1,7 +1,6 @@
 package com.team_nebula.nebula.domain.keyword.repository;
 
 import com.team_nebula.nebula.domain.keyword.entity.Keyword;
-import com.team_nebula.nebula.domain.star.entity.Star;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.query.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,14 +8,13 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.UUID;
 
-public interface KeywordRepository extends Neo4jRepository<Keyword, Long> {
+public interface KeywordRepository extends Neo4jRepository<Keyword, String> {
     @Query("""
-        UNWIND $keywordNames AS keywordName
-        MERGE (k:Keyword {name: keywordName})
-        WITH k
+        UNWIND apoc.coll.toSet($keywordNames) AS keywordName
         MATCH (s:Star {id: $starId})
-        MERGE (s)-[:TAGGED]->(k)
-        RETURN s
+        MERGE (k:Keyword {name: keywordName})
+        WITH s, k
+        MERGE (s)-[:TAGGED]->(k);
     """)
-    Star linkStarToKeywords(@Param("starId") UUID starId, @Param("keywordNames") List<String> keywordNames);
+    void linkStarToKeywords(@Param("starId") UUID starId, @Param("keywordNames") List<String> keywordNames);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandService.java
@@ -5,5 +5,5 @@ import com.team_nebula.nebula.domain.star.entity.Star;
 import java.util.List;
 
 public interface KeywordCommandService {
-    public Star linkStarToKeywords(Star star, List<String> keywordNames);
+    public void linkStarToKeywords(Star star, List<String> keywordNames);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandService.java
@@ -5,5 +5,5 @@ import com.team_nebula.nebula.domain.star.entity.Star;
 import java.util.List;
 
 public interface KeywordCommandService {
-    public void linkStarToKeywords(Star star, List<String> keywordNames);
+    public Star linkStarToKeywords(Star star, List<String> keywordNames);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
@@ -18,10 +18,16 @@ public class KeywordCommandServiceImpl implements KeywordCommandService {
     private final KeywordRepository keywordRepository;
 
     @Override
-    public void linkStarToKeywords(Star star, List<String> keywordNames) {
+    public Star linkStarToKeywords(Star star, List<String> keywordNames) {
         if (keywordNames == null || keywordNames.isEmpty()) {
+            throw new GeneralException(ErrorStatus._KEYWORD_NOT_INPUT);
+        }
+        Star starWithKeywords = keywordRepository.linkStarToKeywords(star.getId(), keywordNames);
+
+        if (star.getKeywords() == null) {
             throw new GeneralException(ErrorStatus._KEYWORD_NOT_FOUND);
         }
-        keywordRepository.linkStarToKeywords(star.getId(), keywordNames);
+
+        return starWithKeywords;
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
@@ -18,16 +18,17 @@ public class KeywordCommandServiceImpl implements KeywordCommandService {
     private final KeywordRepository keywordRepository;
 
     @Override
-    public Star linkStarToKeywords(Star star, List<String> keywordNames) {
+    public void linkStarToKeywords(Star star, List<String> keywordNames) {
         if (keywordNames == null || keywordNames.isEmpty()) {
             throw new GeneralException(ErrorStatus._KEYWORD_NOT_INPUT);
         }
-        Star starWithKeywords = keywordRepository.linkStarToKeywords(star.getId(), keywordNames);
+        System.out.println("----------------------------------------------");
+        System.out.println("스타 아이디 : "+ star.getId());
+        System.out.println("----------------------------------------------");
+        keywordRepository.linkStarToKeywords(star.getId(), keywordNames);
 
         if (star.getKeywords() == null) {
             throw new GeneralException(ErrorStatus._KEYWORD_NOT_FOUND);
         }
-
-        return starWithKeywords;
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
@@ -22,9 +22,7 @@ public class KeywordCommandServiceImpl implements KeywordCommandService {
         if (keywordNames == null || keywordNames.isEmpty()) {
             throw new GeneralException(ErrorStatus._KEYWORD_NOT_INPUT);
         }
-        System.out.println("----------------------------------------------");
-        System.out.println("스타 아이디 : "+ star.getId());
-        System.out.println("----------------------------------------------");
+
         keywordRepository.linkStarToKeywords(star.getId(), keywordNames);
 
         if (star.getKeywords() == null) {

--- a/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
@@ -19,8 +19,10 @@ public class Link extends BaseEntity {
     @GeneratedValue
     private long id;
 
+    @Property("sharedKeywordNum")
     private int sharedKeywordNum;
 
+    @Property("similarityScore")
     private double similarityScore;
 
     @Property("linked_two_node_Id")

--- a/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
@@ -10,14 +10,14 @@ import org.springframework.data.neo4j.core.schema.Node;
 import org.springframework.data.neo4j.core.schema.Property;
 
 import java.util.List;
+import java.util.UUID;
 
 @Node
 @Getter
 @NoArgsConstructor
 public class Link extends BaseEntity {
     @Id
-    @GeneratedValue
-    private long id;
+    private UUID id;
 
     @Property("sharedKeywordNum")
     private int sharedKeywordNum;
@@ -26,10 +26,11 @@ public class Link extends BaseEntity {
     private double similarityScore;
 
     @Property("linked_two_node_Id")
-    private List<Long> linkedNode;
+    private List<UUID> linkedNode;
 
     @Builder
-    public Link(int sharedKeywordNum, double similarityScore, List<Long> linkedNode) {
+    public Link(int sharedKeywordNum, double similarityScore, List<UUID> linkedNode) {
+        this.id = UUID.randomUUID();
         this.sharedKeywordNum = sharedKeywordNum;
         this.similarityScore = similarityScore;
         this.linkedNode = linkedNode;

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public interface LinkRepository extends Neo4jRepository<Link, Long> {
 
@@ -20,7 +21,7 @@ public interface LinkRepository extends Neo4jRepository<Link, Long> {
         MERGE (s1)-[:LINKED]->(l)
         MERGE (s2)-[:LINKED]->(l)
     """)
-    void createLinksBetweenStars(@Param("starId") Long starId);
+    void createLinksBetweenStars(@Param("starId") UUID starId);
 
     @Query("""
         MATCH (s:Star)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
@@ -43,7 +44,7 @@ public interface LinkRepository extends Neo4jRepository<Link, Long> {
            l.sharedKeywordNum AS sharedKeywordNum, 
            l.similarityScore AS similarity
     """)
-    List<Map<String, Object>> findLinkInCategory(@Param("userId") Long userId, @Param("categoryId") Long categoryId);
+    List<Map<String, Object>> findLinkInCategory(@Param("userId") Long userId, @Param("categoryId") UUID categoryId);
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:TAGGED]->(k:Keyword)

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -9,15 +9,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public interface LinkRepository extends Neo4jRepository<Link, Long> {
+public interface LinkRepository extends Neo4jRepository<Link, UUID> {
 
     @Query("""
-        MATCH (s1:Star)-[:HAS_KEYWORD]->(k:Keyword)<-[:HAS_KEYWORD]-(s2:Star)
+        MATCH (s1:Star)-[:TAGGED]->(k:Keyword)<-[:TAGGED]-(s2:Star)
         WHERE s1.id = $starId AND s1 <> s2
         WITH s1, s2, COUNT(k) AS sharedKeywordNum
         WHERE sharedKeywordNum > 0
         MERGE (l:Link {linked_two_node_Id: [s1.id, s2.id]})
-        ON CREATE SET l.sharedKeywordNum = sharedKeywordNum, l.similarityScore = 0.5
+        ON CREATE SET l.sharedKeywordNum = sharedKeywordNum, l.similarityScore = 0.5, l.id = randomUUID()
         MERGE (s1)-[:LINKED]->(l)
         MERGE (s2)-[:LINKED]->(l)
     """)

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryService.java
@@ -4,11 +4,12 @@ import com.team_nebula.nebula.domain.star.dto.response.GetLinkOneResponseDTO;
 import com.team_nebula.nebula.domain.user.entity.UserNode;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface LinkQueryService {
     public List<GetLinkOneResponseDTO> getAllLink(UserNode userNode);
 
-    public List<GetLinkOneResponseDTO> getLinkInCategory(Long userId, Long categoryId);
+    public List<GetLinkOneResponseDTO> getLinkInCategory(Long userId, UUID categoryId);
 
     public List<GetLinkOneResponseDTO> getLinkInKeyword(Long userId, Long keywordId);
 

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -36,7 +37,7 @@ public class LinkQueryServiceImpl implements LinkQueryService {
 
     // 카테고리별 링크 노드 조회
     @Override
-    public List<GetLinkOneResponseDTO> getLinkInCategory(Long userId, Long categoryId){
+    public List<GetLinkOneResponseDTO> getLinkInCategory(Long userId, UUID categoryId){
         List<Map<String, Object>> linkDataList = linkRepository.findLinkInCategory(userId, categoryId);
 
         return linkDataList.stream()

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkQueryServiceImpl.java
@@ -29,7 +29,7 @@ public class LinkQueryServiceImpl implements LinkQueryService {
                         .linkId(((Link) data.get("l")).getId())
                         .sharedKeywordNum((int) data.get("sharedKeywordNum"))
                         .similarity((double) data.get("similarity"))
-                        .linkedNodeIdList((List<Long>) data.get("linkedNodeIdList"))
+                        .linkedNodeIdList((List<UUID>) data.get("linkedNodeIdList"))
                         .build())
                 .toList();
 
@@ -45,7 +45,7 @@ public class LinkQueryServiceImpl implements LinkQueryService {
                         .linkId(((Link) data.get("l")).getId())
                         .sharedKeywordNum((int) data.get("sharedKeywordNum"))
                         .similarity((double) data.get("similarity"))
-                        .linkedNodeIdList((List<Long>) data.get("linkedNodeIdList"))
+                        .linkedNodeIdList((List<UUID>) data.get("linkedNodeIdList"))
                         .build())
                 .toList();
     }
@@ -60,7 +60,7 @@ public class LinkQueryServiceImpl implements LinkQueryService {
                         .linkId(((Link) data.get("l")).getId())
                         .sharedKeywordNum((int) data.get("sharedKeywordNum"))
                         .similarity((double) data.get("similarity"))
-                        .linkedNodeIdList((List<Long>) data.get("linkedNodeIdList"))
+                        .linkedNodeIdList((List<UUID>) data.get("linkedNodeIdList"))
                         .build())
                 .toList();
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -11,8 +11,11 @@ import com.team_nebula.nebula.global.annotation.AuthUser;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,15 +27,16 @@ public class StarController {
     private final StarQueryService starQueryService;
 
     // 스타 생성 API
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<CreateStarResponseDTO> createStar(
+            @AuthUser User user,
             @RequestPart(value = "thumbnailImage",required = false) MultipartFile thumbnailImage,
             @RequestPart(value = "htmlFile",required = false) MultipartFile htmlFile,
             @RequestPart(value = "star JSON data") String starJsonData
     ){
         CreateStarFileDTO requestDTO = starQueryService.starDataParsing(thumbnailImage, htmlFile, starJsonData);
 
-        CreateStarResponseDTO responseDTO = starCommandService.createStar(requestDTO);
+        CreateStarResponseDTO responseDTO = starCommandService.createStar(user, requestDTO);
 
         return ApiResponse.onSuccessCreated(responseDTO);
     }
@@ -47,7 +51,7 @@ public class StarController {
 
     // 스타 단일 조회 API
     @GetMapping("/{starId}")
-    public ApiResponse<GetStarOneResponseDTO> getStarOne(@PathVariable Long starId){
+    public ApiResponse<GetStarOneResponseDTO> getStarOne(@PathVariable UUID starId){
         GetStarOneResponseDTO responseDTO = starQueryService.getStarOne(starId);
 
         return ApiResponse.onSuccess(responseDTO);
@@ -55,7 +59,7 @@ public class StarController {
 
     // 카테고리별 스타 조회 API
     @GetMapping("/categories/{categoryId}")
-    public ApiResponse<GetStarListResponseDTO> getStarListByCategory(@AuthUser User user, @PathVariable Long categoryId){
+    public ApiResponse<GetStarListResponseDTO> getStarListByCategory(@AuthUser User user, @PathVariable UUID categoryId){
         GetStarListResponseDTO responseDTO = starQueryService.getStarListInCategory(user.getId(), categoryId);
 
         return ApiResponse.onSuccess(responseDTO);

--- a/src/main/java/com/team_nebula/nebula/domain/star/converter/StarConverter.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/converter/StarConverter.java
@@ -5,10 +5,7 @@ import com.team_nebula.nebula.domain.star.dto.response.GetStarListResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
 import com.team_nebula.nebula.domain.star.entity.Star;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class StarConverter {
 
@@ -30,10 +27,10 @@ public class StarConverter {
 
     public static GetLinkOneResponseDTO convertToLinkOneDto(Map<String, Object> data) {
         return GetLinkOneResponseDTO.builder()
-                .linkId((Long) data.get("linkId"))
+                .linkId((UUID) data.get("linkId"))
                 .sharedKeywordNum((Integer) data.get("sharedKeywordNum"))
                 .similarity((Double) data.get("similarity"))
-                .linkedNodeIdList((List<Long>) data.get("linkedNodeIdList"))
+                .linkedNodeIdList((List<UUID>) data.get("linkedNodeIdList"))
                 .build();
     }
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
@@ -1,14 +1,18 @@
 package com.team_nebula.nebula.domain.star.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CreateStarRequestDTO {
 
-    private Long userId;
     private String title;
     private String siteUrl;
     private String summaryAI;

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/CreateStarResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/CreateStarResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Builder
@@ -13,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor
 public class CreateStarResponseDTO {
 
-    private Long starId;
+    private UUID starId;
     private String title;
     private String categoryName;
     private List<String> keywordList;

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetLinkOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetLinkOneResponseDTO.java
@@ -6,14 +6,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class GetLinkOneResponseDTO {
-    private Long linkId;
+    private UUID linkId;
     private int sharedKeywordNum;
     private double similarity;
-    private List<Long> linkedNodeIdList;
+    private List<UUID> linkedNodeIdList;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetStarOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetStarOneResponseDTO.java
@@ -6,13 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class GetStarOneResponseDTO {
-    private Long starId;
+    private UUID starId;
     private String categoryName;
     private String title;
     private String siteUrl;

--- a/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
@@ -3,7 +3,6 @@ package com.team_nebula.nebula.domain.star.entity;
 import com.team_nebula.nebula.domain.common.BaseEntity;
 import com.team_nebula.nebula.domain.keyword.entity.Keyword;
 import com.team_nebula.nebula.domain.link.entity.Link;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Lob;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +14,7 @@ import org.springframework.data.neo4j.core.schema.Relationship;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 @Node
 @Getter
@@ -22,8 +22,7 @@ import java.util.Set;
 public class Star extends BaseEntity {
 
     @Id
-    @GeneratedValue
-    private Long id;
+    private UUID id;
 
     private String title;
 
@@ -37,9 +36,11 @@ public class Star extends BaseEntity {
     private String summaryAI;
 
     @Lob
+    @Property("userMemo")
     private String userMemo;
 
     // 조회수
+    @Property("views")
     private int views;
 
     @Property("html_file_url")
@@ -56,6 +57,7 @@ public class Star extends BaseEntity {
     @Builder
     public Star(String title, String siteUrl, String thumbnailUrl, String summaryAI, String userMemo, String memoUser, int views,
                 String htmlFileUrl, String embedding) {
+        this.id = UUID.randomUUID();
         this.title = title;
         this.siteUrl = siteUrl;
         this.thumbnailUrl = thumbnailUrl;

--- a/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
@@ -41,7 +41,7 @@ public class Star extends BaseEntity {
 
     // 조회수
     @Property("views")
-    private int views;
+    private Integer views;
 
     @Property("html_file_url")
     private String htmlFileUrl;

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
@@ -8,8 +8,9 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
-public interface StarRepository extends Neo4jRepository<Star, Long> {
+public interface StarRepository extends Neo4jRepository<Star, UUID> {
     @Query("""
         MATCH (u:UserNode)-[:CREATED]->(s:Star)
         WHERE u.userId = $userId
@@ -27,7 +28,7 @@ public interface StarRepository extends Neo4jRepository<Star, Long> {
         WHERE ID(s) = $starId
         RETURN s AS s, c.name AS categoryName, COLLECT(k.name) AS keywordList
     """)
-    Optional<Map<String, Object>> findStarDetailById(@Param("starId") Long starId);
+    Optional<Map<String, Object>> findStarDetailById(@Param("starId") UUID starId);
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:BELONGS_TO]->(c:Category)
@@ -37,7 +38,7 @@ public interface StarRepository extends Neo4jRepository<Star, Long> {
            c.name AS categoryName, 
            COLLECT(k.name) AS keywordList
     """)
-    List<Map<String, Object>> findStarsInCategory(@Param("userId") Long userId, @Param("categoryId") Long categoryId);
+    List<Map<String, Object>> findStarsInCategory(@Param("userId") Long userId, @Param("categoryId") UUID categoryId);
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:TAGGED]->(k:Keyword)

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -2,8 +2,9 @@ package com.team_nebula.nebula.domain.star.service;
 
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
+import com.team_nebula.nebula.domain.user.entity.User;
 
 public interface StarCommandService {
 
-    public CreateStarResponseDTO createStar(CreateStarFileDTO requestDTO);
+    public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -10,6 +10,7 @@ import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.domain.star.repository.StarRepository;
+import com.team_nebula.nebula.domain.user.entity.User;
 import com.team_nebula.nebula.domain.user.entity.UserNode;
 import com.team_nebula.nebula.domain.user.repository.neo4j.UserNodeRepository;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
@@ -17,6 +18,8 @@ import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,11 +34,10 @@ public class StarCommandServiceImpl implements StarCommandService {
     private final S3Service s3Service;
 
     @Override
-    public CreateStarResponseDTO createStar(CreateStarFileDTO requestDTO){
+    public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO){
         CreateStarRequestDTO starRequestDTO = requestDTO.getStarRequestDTO();
 
-        // 유저 인증
-        UserNode userNode = userNodeRepository.findByUserId(starRequestDTO.getUserId())
+        UserNode userNode = userNodeRepository.findById(user.getId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
         // 스타 생성 및 유저와 관계 설정
@@ -45,18 +47,21 @@ public class StarCommandServiceImpl implements StarCommandService {
         categoryCommandService.linkStarToCategory(star, starRequestDTO.getCategoryName());
 
         // 키워드 생성 및 관계 설정
-        keywordCommandService.linkStarToKeywords(star, starRequestDTO.getKeywordList());
+        Star savedStar = keywordCommandService.linkStarToKeywords(star, starRequestDTO.getKeywordList());
+        if(savedStar.getId() == null) {
+            throw new GeneralException(ErrorStatus._STAR_NOT_FOUND);
+        }
 
         // 스타 간 Link 노드 생성
-        linkCommandService.createLinksForStar(star);
+        linkCommandService.createLinksForStar(savedStar);
 
         return CreateStarResponseDTO.builder()
                 .starId(star.getId())
                 .title(star.getTitle())
                 .categoryName(starRequestDTO.getCategoryName())
-                .keywordList(star.getKeywords().stream()
+                .keywordList(savedStar.getKeywords().stream()
                         .map(Keyword::getName)
-                        .toList())
+                        .collect(Collectors.toList()))
                 .build();
 
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -47,10 +47,11 @@ public class StarCommandServiceImpl implements StarCommandService {
         categoryCommandService.linkStarToCategory(star, starRequestDTO.getCategoryName());
 
         // 키워드 생성 및 관계 설정
-        Star savedStar = keywordCommandService.linkStarToKeywords(star, starRequestDTO.getKeywordList());
-        if(savedStar.getId() == null) {
-            throw new GeneralException(ErrorStatus._STAR_NOT_FOUND);
-        }
+        keywordCommandService.linkStarToKeywords(star, starRequestDTO.getKeywordList());
+
+        // 키워드+ 카테고리 포함된 스타를 다시 조회
+        Star savedStar = starRepository.findById(star.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
         // 스타 간 Link 노드 생성
         linkCommandService.createLinksForStar(savedStar);

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
@@ -7,6 +7,7 @@ import com.team_nebula.nebula.domain.user.entity.UserNode;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface StarQueryService {
 
@@ -16,11 +17,11 @@ public interface StarQueryService {
 
     public List<GetStarOneResponseDTO> findAllStar(UserNode userNode);
 
-    public GetStarOneResponseDTO getStarOne(Long starId);
+    public GetStarOneResponseDTO getStarOne(UUID starId);
 
-    public GetStarListResponseDTO getStarListInCategory(Long userId, Long categoryId);
+    public GetStarListResponseDTO getStarListInCategory(Long userId, UUID categoryId);
 
-    public List<GetStarOneResponseDTO> findStarInCategory(Long userId, Long categoryId);
+    public List<GetStarOneResponseDTO> findStarInCategory(Long userId, UUID categoryId);
 
     public GetStarListResponseDTO getStarListInKeyword(Long userId, Long keywordId);
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.team_nebula.nebula.domain.star.service;
 
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.team_nebula.nebula.domain.link.service.LinkQueryService;
@@ -19,8 +20,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -33,14 +36,24 @@ public class StarQueryServiceImpl implements StarQueryService {
 
     // 스타 JSON 데이터 파싱
     @Override
-    public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData){
-
+    public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData) {
         ObjectMapper objectMapper = new ObjectMapper();
+
+        // LocalDateTime 처리
         objectMapper.registerModule(new JavaTimeModule());
 
-        // starJsonData 파싱
+        // 컨트롤문자 허용
+        objectMapper.configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature(), true);
+        // 작은따옴표 허용
+        objectMapper.configure(JsonReadFeature.ALLOW_SINGLE_QUOTES.mappedFeature(), true);
+        // \ 이스테이프 허용
+        objectMapper.configure(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER.mappedFeature(), true);
+
         CreateStarRequestDTO request;
         try {
+            // 유니코드 깨짐 방지
+            starJsonData = new String(starJsonData.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+
             request = objectMapper.readValue(starJsonData, CreateStarRequestDTO.class);
         } catch (Exception e) {
             e.printStackTrace();
@@ -52,8 +65,8 @@ public class StarQueryServiceImpl implements StarQueryService {
                 .htmlFile(htmlFile)
                 .starRequestDTO(request)
                 .build();
-
     }
+
 
     // 스타 + 링크 전체 조회
     @Override
@@ -90,7 +103,7 @@ public class StarQueryServiceImpl implements StarQueryService {
 
     // 단일 스타 조회
     @Override
-    public GetStarOneResponseDTO getStarOne(Long starId) {
+    public GetStarOneResponseDTO getStarOne(UUID starId) {
         Map<String, Object> data = starRepository.findStarDetailById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
@@ -99,7 +112,7 @@ public class StarQueryServiceImpl implements StarQueryService {
 
     // 카테고리별 스타 조회
     @Override
-    public GetStarListResponseDTO getStarListInCategory(Long userId, Long categoryId){
+    public GetStarListResponseDTO getStarListInCategory(Long userId, UUID categoryId){
 
         // 유저 인증
         UserNode userNode = userNodeRepository.findByUserId(userId)
@@ -118,7 +131,7 @@ public class StarQueryServiceImpl implements StarQueryService {
     }
 
     @Override
-    public List<GetStarOneResponseDTO> findStarInCategory(Long userId, Long categoryId) {
+    public List<GetStarOneResponseDTO> findStarInCategory(Long userId, UUID categoryId) {
         List<Map<String, Object>> starDataList = starRepository.findStarsInCategory(userId, categoryId);
 
         return starDataList.stream()

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -46,7 +46,7 @@ public class StarQueryServiceImpl implements StarQueryService {
         objectMapper.configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature(), true);
         // 작은따옴표 허용
         objectMapper.configure(JsonReadFeature.ALLOW_SINGLE_QUOTES.mappedFeature(), true);
-        // \ 이스테이프 허용
+        // \ 이스케이프 허용
         objectMapper.configure(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER.mappedFeature(), true);
 
         CreateStarRequestDTO request;

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -24,7 +24,8 @@ public enum ErrorStatus implements BaseErrorCode {
 	_STAR_NOT_FOUND(HttpStatus.NOT_FOUND, "STAR4001", "해당 스타 정보를 찾을 수 없습니다."),
 	_STAR_CREATION_FAILED(HttpStatus.CREATED, "STAR5000", "스타 생성에 실패했습니다."),
 
-	_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD4001", "키워드가 존재하지 않습니다."),
+	_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD4001", "해당 스타안에 키워드를 찾지 못했습니다."),
+	_KEYWORD_NOT_INPUT(HttpStatus.NOT_ACCEPTABLE, "KEYWORD4002", "키워드가 입력되지 않았습니다."),
 
 	_MULTIPARTFILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,"MULTIPARTFILE5000","MultipartFile -> File로 변환이 실패하였습니다.");
 


### PR DESCRIPTION
## 💡 개요
스타 생성 시 발생하는 에러 수정

## 🔨작업 사항
### 스타 생성 Swagger 수정
![image](https://github.com/user-attachments/assets/f5ffd2f8-e207-4393-824a-8c12d7dbe468)
- RequestBody 타입이 multipart/form-data 여서 consumes 타입 추가

### 각 노드 Id 타입 UUID로 수정
- 카테고리 에러 잡을때도 언급했지만 노드 내부 id는 반환이 안되고 재사용 가능성이 있기 때문에 각 노드 id 타입을 UUID 타입으로 수정함
- 예외로 키워드 노드는 name을 Id로 잡았는데 이유가 스타와 키워드 노드 관계 생성 시 merge 쿼리를 사용하는데 Long id로 하면 추가적인 속성(id 등)이 자동으로 생성되서 중복 키워드가 발생하는 오류가 발생함
- 그래서 나중에 Keyword 기능 개발 할때 참고하시길. name으로 개발하기 힘들면 나중에 논의해보면 좋을듯

### S3 사용자 설정
![image](https://github.com/user-attachments/assets/95fa0ac7-8dd5-4311-ac3a-8ef5e93e73ba)
- 현재는 테스트를 위해 본인 사용자만 추가해놨는데 나중에 사용자 그룹만들어서 수정해야할듯
- 더 좋은 방법 있으면 의견주시면 감사하겠습니다.

### 생성된 모습
![image](https://github.com/user-attachments/assets/3f5ee7a6-d384-43ed-a67e-db4aeacf1867)
![image](https://github.com/user-attachments/assets/936dc02e-7231-4ade-b43d-b5ba3af4ab00)
- 공통 키워드 존재 여부에 따라 링크 노드가 생성이 결정됨(사진에서 핑크색이 링크 노드)
- 테스트 하면서 보니까 노드를 삭제하면 관계가 있는 노드도 다 삭제됨. 근데 노드에 다른 관계가 있으면 관계가 있던 노드가 있어도 삭제되지 않음. 노드를 고립시키지 않는다는 것.

## 📝 기타 (선택)
