### PR TITLE
SCRUM 145 : 스타 수정 및 삭제 API 구현 + 스타 생성 플로우 수정

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
@@ -23,4 +23,21 @@ public interface CategoryRepository extends Neo4jRepository<Category, UUID> {
 
     Optional<Category> findByName(String name);
 
+    @Query("""
+    MATCH (c:Category)<-[:BELONGS_TO]-(s:Star{id: $starId})
+    RETURN c.name
+    """)
+    String findByStar(UUID starId);
+
+    @Query("""
+    MATCH (s:Star {id: $starId})-[r:BELONGS_TO]->(c:Category)
+    DELETE r
+    WITH s
+    MATCH (newCategory:Category {name: $categoryName})
+    MERGE (s)-[:BELONGS_TO]->(newCategory)
+    RETURN newCategory.name
+    """)
+    String findNameByStarAndRemoveRelation(@Param("starId") UUID starId, @Param("categoryName") String categoryName);
+
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
@@ -21,6 +21,7 @@ public interface CategoryRepository extends Neo4jRepository<Category, UUID> {
     """)
     List<GetCategoryOneResponseDTO> findUserCategoriesWithStarCount(@Param("userId") Long userId);
 
+    @Query("MATCH (c:Category) WHERE c.name = $name RETURN c")
     Optional<Category> findByName(String name);
 
     @Query("""

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandService.java
@@ -10,4 +10,6 @@ public interface CategoryCommandService {
 
     public void linkStarToCategory(Star star, String categoryName);
 
+    public String linkStarToCategoryAndGetName(Star star, String categoryName);
+
     }

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
@@ -61,6 +61,14 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
         categoryRepository.save(category);
     }
 
+    @Override
+    public String linkStarToCategoryAndGetName(Star star, String categoryName){
+
+        String cname = categoryRepository.findNameByStarAndRemoveRelation(star.getId(), categoryName);
+
+        return cname;
+    }
+
 }
 
 

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryQueryService.java
@@ -2,6 +2,10 @@ package com.team_nebula.nebula.domain.category.service;
 
 import com.team_nebula.nebula.domain.category.dto.response.GetCategoryListResponseDTO;
 
+import java.util.UUID;
+
 public interface CategoryQueryService {
     public GetCategoryListResponseDTO getCategoryList(Long userId);
-}
+
+    public String findCategoryNameByStar(UUID starId);
+    }

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryQueryServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -25,5 +26,11 @@ public class CategoryQueryServiceImpl implements CategoryQueryService {
                 .totalCount(categoryList.size())
                 .categoryList(categoryList)
                 .build();
+    }
+
+    public String findCategoryNameByStar(UUID starId){
+        String name = categoryRepository.findByStar(starId);
+
+        return name;
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/image/S3Service.java
+++ b/src/main/java/com/team_nebula/nebula/domain/image/S3Service.java
@@ -33,24 +33,40 @@ public class S3Service {
     private static final String HTML_FILE_DIR = "html_files/";
 
     public String saveThumbnail(MultipartFile thumbnailImage, String dataInfo) {
-        return uploadToS3(thumbnailImage, THUMBNAIL_DIR, dataInfo);
+        return uploadThumbnailToS3(thumbnailImage, THUMBNAIL_DIR, dataInfo);
     }
 
     public String saveHtmlFile(MultipartFile htmlFile, String dataInfo) {
-        return uploadToS3(htmlFile, HTML_FILE_DIR, dataInfo);
+        return uploadHtmlToS3(htmlFile, HTML_FILE_DIR, dataInfo);
     }
 
-    private String uploadToS3(MultipartFile file, String dirName, String dataInfo)  {
+    private String uploadHtmlToS3(MultipartFile file, String dirName, String dataInfo)  {
         File uploadFile = convert(file)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MULTIPARTFILE_CONVERT_FAIL));
 
         String fileName = dirName + dataInfo + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
-        String fileUrl = putS3(uploadFile, fileName);
+
+        putHtmlS3(uploadFile, fileName);
+        removeNewFile(uploadFile);
+        return fileName;
+    }
+
+    private String uploadThumbnailToS3(MultipartFile file, String dirName, String dataInfo)  {
+        File uploadFile = convert(file)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MULTIPARTFILE_CONVERT_FAIL));
+
+        String fileName = dirName + dataInfo + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+        String fileUrl = putThumbnailS3(uploadFile, fileName);
         removeNewFile(uploadFile);
         return fileUrl;
     }
 
-    private String putS3(File uploadFile, String fileName) {
+    private void putHtmlS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile));
+    }
+
+    private String putThumbnailS3(File uploadFile, String fileName) {
         amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile));
 
         return amazonS3Client.getUrl(bucket, fileName).toString();

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -1,6 +1,7 @@
 package com.team_nebula.nebula.domain.star.api;
 
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
+import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetSearchedStarListResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetStarListResponseDTO;
@@ -79,6 +80,17 @@ public class StarController {
     @GetMapping("/search")
     public ApiResponse<GetSearchedStarListResponseDTO> searchStar(@RequestParam String title, @AuthUser User user){
         GetSearchedStarListResponseDTO responseDTO = starQueryService.searchStars(user.getId(), title);
+
+        return ApiResponse.onSuccess(responseDTO);
+    }
+
+    // 스타 수정 API
+    @PatchMapping("/{starId}")
+    public ApiResponse<GetStarOneResponseDTO> updateStar(
+            @PathVariable UUID starId,
+            @RequestBody UpdateStarOneRequestDTO requestDTO
+    ){
+        GetStarOneResponseDTO responseDTO = starCommandService.updateStar(starId, requestDTO);
 
         return ApiResponse.onSuccess(responseDTO);
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -2,10 +2,7 @@ package com.team_nebula.nebula.domain.star.api;
 
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
-import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
-import com.team_nebula.nebula.domain.star.dto.response.GetSearchedStarListResponseDTO;
-import com.team_nebula.nebula.domain.star.dto.response.GetStarListResponseDTO;
-import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.*;
 import com.team_nebula.nebula.domain.star.service.StarCommandService;
 import com.team_nebula.nebula.domain.star.service.StarQueryService;
 import com.team_nebula.nebula.domain.user.entity.User;
@@ -28,17 +25,19 @@ public class StarController {
     private final StarCommandService starCommandService;
     private final StarQueryService starQueryService;
 
-    // 스타 생성 API
+    // 스타 생성 API(크롬 익스텐션에서 추가하는 경우)
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<CreateStarResponseDTO> createStar(
             @AuthUser User user,
             @RequestPart(value = "thumbnailImage",required = false) MultipartFile thumbnailImage,
             @RequestPart(value = "htmlFile",required = false) MultipartFile htmlFile,
-            @RequestPart(value = "star JSON data") String starJsonData
-    ){
-        CreateStarFileDTO requestDTO = starQueryService.starDataParsing(thumbnailImage, htmlFile, starJsonData);
+            @RequestPart(value = "사이트 제목") String title,
+            @RequestPart(value = "사이트 주소") String siteUrl
 
-        CreateStarResponseDTO responseDTO = starCommandService.createStar(user, requestDTO);
+    ){
+//        CreateStarFileDTO requestDTO = starQueryService.starDataParsing(thumbnailImage, htmlFile, starJsonData);
+
+        CreateStarResponseDTO responseDTO = starCommandService.createFirstStar(user, thumbnailImage, htmlFile, title, siteUrl);
 
         return ApiResponse.onSuccessCreated(responseDTO);
     }
@@ -91,6 +90,14 @@ public class StarController {
             @RequestBody UpdateStarOneRequestDTO requestDTO
     ){
         GetStarOneResponseDTO responseDTO = starCommandService.updateStar(starId, requestDTO);
+
+        return ApiResponse.onSuccess(responseDTO);
+    }
+
+    // 스타 삭제 API
+    @PatchMapping("/delete/{starId}")
+    public ApiResponse<DeleteStarResponseDTO> deleteStar(@AuthUser User user, @PathVariable UUID starId){
+        DeleteStarResponseDTO responseDTO = starCommandService.deleteStar(starId);
 
         return ApiResponse.onSuccess(responseDTO);
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -1,6 +1,7 @@
 package com.team_nebula.nebula.domain.star.api;
 
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
+import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.*;
 import com.team_nebula.nebula.domain.star.service.StarCommandService;
@@ -29,17 +30,21 @@ public class StarController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<CreateStarResponseDTO> createStar(
             @AuthUser User user,
-            @RequestPart(value = "thumbnailImage",required = false) MultipartFile thumbnailImage,
             @RequestPart(value = "htmlFile",required = false) MultipartFile htmlFile,
             @RequestPart(value = "사이트 제목") String title,
             @RequestPart(value = "사이트 주소") String siteUrl
 
     ){
-//        CreateStarFileDTO requestDTO = starQueryService.starDataParsing(thumbnailImage, htmlFile, starJsonData);
-
-        CreateStarResponseDTO responseDTO = starCommandService.createFirstStar(user, thumbnailImage, htmlFile, title, siteUrl);
+        CreateStarResponseDTO responseDTO = starCommandService.createFirstStar(user, htmlFile, title, siteUrl);
 
         return ApiResponse.onSuccessCreated(responseDTO);
+    }
+
+    @PatchMapping("/complete/{starId}")
+    public ApiResponse<PutStarResponseDTO> putStar(@PathVariable UUID starId, @RequestBody CreateStarRequestDTO requestDTO){
+        PutStarResponseDTO responseDTO = starCommandService.putStar(starId, requestDTO);
+
+        return ApiResponse.onSuccess(responseDTO);
     }
 
     // 스타 전체 조회 API

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -1,6 +1,5 @@
 package com.team_nebula.nebula.domain.star.api;
 
-import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.*;
@@ -31,18 +30,18 @@ public class StarController {
     public ApiResponse<CreateStarResponseDTO> createStar(
             @AuthUser User user,
             @RequestPart(value = "htmlFile",required = false) MultipartFile htmlFile,
-            @RequestPart(value = "사이트 제목") String title,
-            @RequestPart(value = "사이트 주소") String siteUrl
-
+            @RequestParam(value = "title") String title,
+            @RequestParam(value = "siteUrl") String siteUrl
     ){
         CreateStarResponseDTO responseDTO = starCommandService.createFirstStar(user, htmlFile, title, siteUrl);
 
         return ApiResponse.onSuccessCreated(responseDTO);
     }
 
+    // 스타 수정 API(데이터 입력 후 나머지 노드 생성)
     @PatchMapping("/complete/{starId}")
-    public ApiResponse<PutStarResponseDTO> putStar(@PathVariable UUID starId, @RequestBody CreateStarRequestDTO requestDTO){
-        PutStarResponseDTO responseDTO = starCommandService.putStar(starId, requestDTO);
+    public ApiResponse<PutStarResponseDTO> updateStar(@PathVariable UUID starId, @RequestBody CreateStarRequestDTO requestDTO){
+        PutStarResponseDTO responseDTO = starCommandService.updateStar(starId, requestDTO);
 
         return ApiResponse.onSuccess(responseDTO);
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarFileDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarFileDTO.java
@@ -7,7 +7,6 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 @Builder
 public class CreateStarFileDTO {
-    private MultipartFile thumbnailImage;
     private MultipartFile htmlFile;
 //    private CreateStarRequestDTO starRequestDTO;
     private String title;

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarFileDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarFileDTO.java
@@ -9,5 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class CreateStarFileDTO {
     private MultipartFile thumbnailImage;
     private MultipartFile htmlFile;
-    private CreateStarRequestDTO starRequestDTO;
+//    private CreateStarRequestDTO starRequestDTO;
+    private String title;
+    private String siteUrl;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
@@ -13,8 +13,8 @@ import java.util.List;
 @AllArgsConstructor
 public class CreateStarRequestDTO {
 
-    private String title;
-    private String siteUrl;
+//    private String title;
+//    private String siteUrl;
     private String summaryAI;
     private String userMemo;
     private String embedding;

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
@@ -13,8 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 public class CreateStarRequestDTO {
 
-//    private String title;
-//    private String siteUrl;
+    private String thumbnailUrl;
     private String summaryAI;
     private String userMemo;
     private String embedding;

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/UpdateStarOneRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/UpdateStarOneRequestDTO.java
@@ -1,0 +1,17 @@
+package com.team_nebula.nebula.domain.star.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateStarOneRequestDTO {
+    String title;
+    String categoryName;
+    String summaryAI;
+    String userMemo;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/DeleteStarResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/DeleteStarResponseDTO.java
@@ -5,15 +5,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
 import java.util.UUID;
 
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class CreateStarResponseDTO {
-
+public class DeleteStarResponseDTO {
     private UUID starId;
-    private String title;
+    private String deleteStatus;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/PutStarResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/PutStarResponseDTO.java
@@ -1,0 +1,20 @@
+package com.team_nebula.nebula.domain.star.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PutStarResponseDTO {
+    private UUID starId;
+    private String title;
+    private String categoryName;
+    private List<String> keywordList;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
@@ -48,6 +48,9 @@ public class Star extends BaseEntity {
 
     private String embedding;
 
+    @Property("Deleted status")
+    private Boolean isDeletedStatus;
+
     @Relationship(type = "LINKED", direction = Relationship.Direction.OUTGOING)
     private Set<Link> links = new HashSet<>();
 
@@ -66,6 +69,7 @@ public class Star extends BaseEntity {
         this.views = views;
         this.htmlFileUrl = htmlFileUrl;
         this.embedding = embedding;
+        this.isDeletedStatus = false;
     }
 
     public void updateTitle(String title){
@@ -78,5 +82,9 @@ public class Star extends BaseEntity {
 
     public void updateUserMemo(String userMemo){
         this.userMemo = userMemo;
+    }
+
+    public void updateIsDeletedStatus(){
+        this.isDeletedStatus = true;
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
@@ -67,4 +67,16 @@ public class Star extends BaseEntity {
         this.htmlFileUrl = htmlFileUrl;
         this.embedding = embedding;
     }
+
+    public void updateTitle(String title){
+        this.title = title;
+    }
+
+    public void updateSummaryAI(String summaryAI){
+        this.summaryAI = summaryAI;
+    }
+
+    public void updateUserMemo(String userMemo){
+        this.userMemo = userMemo;
+    }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
@@ -72,6 +72,14 @@ public class Star extends BaseEntity {
         this.isDeletedStatus = false;
     }
 
+    public void updateStar(String thumbnailUrl, String summaryAI, String userMemo, String embedding) {
+        this.thumbnailUrl = thumbnailUrl;
+        this.summaryAI = summaryAI;
+        this.userMemo = userMemo;
+        this.embedding = embedding;
+        this.isDeletedStatus = false;
+    }
+
     public void updateTitle(String title){
         this.title = title;
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
@@ -90,7 +90,7 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
     OPTIONAL MATCH (s2)-[:BELONGS_TO]->(c2:Category)
     OPTIONAL MATCH (s2)-[:TAGGED]->(k2:Keyword)
 
-    WITH 
+    WITH
         s, c, COLLECT(DISTINCT k.name) AS keywordList,
         s2, c2, COLLECT(DISTINCT k2.name) AS linkedKeywordList,
         COLLECT(DISTINCT {
@@ -99,7 +99,7 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
             similarity: l.similarityScore
         }) AS links
 
-    RETURN 
+    RETURN
         COLLECT(DISTINCT {
             searchedStar: {
                 starId: s.id,

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -1,6 +1,5 @@
 package com.team_nebula.nebula.domain.star.service;
 
-import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
@@ -18,7 +17,7 @@ public interface StarCommandService {
 
 //    public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO);
 
-    public PutStarResponseDTO putStar(UUID starId, CreateStarRequestDTO requestDTO);
+    public PutStarResponseDTO updateStar(UUID starId, CreateStarRequestDTO requestDTO);
 
     public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO);
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -1,10 +1,16 @@
 package com.team_nebula.nebula.domain.star.service;
 
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
+import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
 import com.team_nebula.nebula.domain.user.entity.User;
+
+import java.util.UUID;
 
 public interface StarCommandService {
 
     public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO);
+
+    public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -3,14 +3,20 @@ package com.team_nebula.nebula.domain.star.service;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.DeleteStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
 import com.team_nebula.nebula.domain.user.entity.User;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
 public interface StarCommandService {
 
+    public CreateStarResponseDTO createFirstStar(User user, MultipartFile htmlFile, MultipartFile thumbnailFile, String title, String siteUrl);
+
     public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO);
 
     public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO);
+
+    public DeleteStarResponseDTO deleteStar(UUID starId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -1,10 +1,12 @@
 package com.team_nebula.nebula.domain.star.service;
 
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
+import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.DeleteStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.PutStarResponseDTO;
 import com.team_nebula.nebula.domain.user.entity.User;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -12,9 +14,11 @@ import java.util.UUID;
 
 public interface StarCommandService {
 
-    public CreateStarResponseDTO createFirstStar(User user, MultipartFile htmlFile, MultipartFile thumbnailFile, String title, String siteUrl);
+    public CreateStarResponseDTO createFirstStar(User user, MultipartFile htmlFile, String title, String siteUrl);
 
-    public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO);
+//    public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO);
+
+    public PutStarResponseDTO putStar(UUID starId, CreateStarRequestDTO requestDTO);
 
     public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO);
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -12,6 +12,7 @@ import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.DeleteStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.domain.star.repository.StarRepository;
@@ -23,6 +24,7 @@ import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -40,6 +42,33 @@ public class StarCommandServiceImpl implements StarCommandService {
     private final KeywordCommandService keywordCommandService;
     private final LinkCommandService linkCommandService;
     private final S3Service s3Service;
+
+    @Override
+    public CreateStarResponseDTO createFirstStar(User user, MultipartFile htmlFile, MultipartFile thumbnailFile, String title, String siteUrl){
+        UserNode userNode = userNodeRepository.findById(user.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        Star star = Star.builder()
+                .title(title)
+                .siteUrl(siteUrl)
+                .thumbnailUrl(s3Service.saveThumbnail(thumbnailFile, title))
+                .htmlFileUrl(s3Service.saveHtmlFile(htmlFile, title))
+                .build();
+
+        Star savedStar = starRepository.save(star);
+        if (savedStar.getId() == null) {
+            throw new GeneralException(ErrorStatus._STAR_CREATION_FAILED);
+        }
+
+        // 유저 노드와 관계 설정 후 저장
+        userNode.getStars().add(savedStar);
+        userNodeRepository.save(userNode);
+
+        return CreateStarResponseDTO.builder()
+                .starId(savedStar.getId())
+                .title(savedStar.getTitle())
+                .build();
+    }
 
     @Override
     public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO){
@@ -142,4 +171,20 @@ public class StarCommandServiceImpl implements StarCommandService {
                         .toList())
                 .build();    
     }
+
+    @Override
+    public DeleteStarResponseDTO deleteStar(UUID starId){
+        Star star = starRepository.findById(starId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
+
+        star.updateIsDeletedStatus();
+        starRepository.save(star);
+
+        String deleteMessage = "Star with ID : " + starId + " was deleted";
+        return DeleteStarResponseDTO.builder()
+                .starId(starId)
+                .deleteStatus(deleteMessage)
+                .build();
+    }
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -1,13 +1,18 @@
 package com.team_nebula.nebula.domain.star.service;
 
+import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
 import com.team_nebula.nebula.domain.category.service.CategoryCommandService;
+import com.team_nebula.nebula.domain.category.service.CategoryQueryService;
 import com.team_nebula.nebula.domain.image.S3Service;
 import com.team_nebula.nebula.domain.keyword.entity.Keyword;
 import com.team_nebula.nebula.domain.keyword.service.KeywordCommandService;
 import com.team_nebula.nebula.domain.link.service.LinkCommandService;
+import com.team_nebula.nebula.domain.star.converter.StarConverter;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
+import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.domain.star.repository.StarRepository;
 import com.team_nebula.nebula.domain.user.entity.User;
@@ -19,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,8 +33,10 @@ import java.util.stream.Collectors;
 public class StarCommandServiceImpl implements StarCommandService {
 
     private final StarRepository starRepository;
+    private final CategoryRepository categoryRepository;
     private final UserNodeRepository userNodeRepository;
     private final CategoryCommandService categoryCommandService;
+    private final CategoryQueryService categoryQueryService;
     private final KeywordCommandService keywordCommandService;
     private final LinkCommandService linkCommandService;
     private final S3Service s3Service;
@@ -93,4 +101,45 @@ public class StarCommandServiceImpl implements StarCommandService {
         return savedStar;
     }
 
+    public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO){
+        Star star = starRepository.findById(starId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
+
+        String categoryName = "";
+
+        if(requestDTO.getTitle() != null){
+            star.updateTitle(requestDTO.getTitle());
+        }
+
+        if(requestDTO.getCategoryName() != null){
+            categoryName = categoryCommandService.linkStarToCategoryAndGetName(star, requestDTO.getCategoryName());
+        }
+        else{
+            categoryName = categoryQueryService.findCategoryNameByStar(star.getId());
+        }
+
+        if(requestDTO.getSummaryAI() != null){
+            star.updateSummaryAI(requestDTO.getSummaryAI());
+        }
+
+        if(requestDTO.getUserMemo() != null){
+            star.updateUserMemo(requestDTO.getUserMemo());
+        }
+
+        Star updateStar = starRepository.save(star);
+
+        return GetStarOneResponseDTO.builder()
+                .starId(updateStar.getId())
+                .categoryName(categoryName)
+                .title(updateStar.getTitle())
+                .siteUrl(updateStar.getSiteUrl())
+                .thumbnailUrl(updateStar.getThumbnailUrl())
+                .summaryAI(updateStar.getSummaryAI())
+                .userMemo(updateStar.getUserMemo())
+                .views(updateStar.getViews())
+                .keywordList(updateStar.getKeywords().stream()
+                        .map(Keyword::getName)
+                        .toList())
+                .build();    
+    }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -14,6 +14,7 @@ import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.DeleteStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.PutStarResponseDTO;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.domain.star.repository.StarRepository;
 import com.team_nebula.nebula.domain.user.entity.User;
@@ -44,14 +45,13 @@ public class StarCommandServiceImpl implements StarCommandService {
     private final S3Service s3Service;
 
     @Override
-    public CreateStarResponseDTO createFirstStar(User user, MultipartFile htmlFile, MultipartFile thumbnailFile, String title, String siteUrl){
+    public CreateStarResponseDTO createFirstStar(User user, MultipartFile htmlFile, String title, String siteUrl){
         UserNode userNode = userNodeRepository.findById(user.getId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
         Star star = Star.builder()
                 .title(title)
                 .siteUrl(siteUrl)
-                .thumbnailUrl(s3Service.saveThumbnail(thumbnailFile, title))
                 .htmlFileUrl(s3Service.saveHtmlFile(htmlFile, title))
                 .build();
 
@@ -70,21 +70,52 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .build();
     }
 
+//    @Override
+//    public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO){
+//        CreateStarRequestDTO starRequestDTO = requestDTO.getStarRequestDTO();
+//
+//        UserNode userNode = userNodeRepository.findById(user.getId())
+//                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+//
+//        // 스타 생성 및 유저와 관계 설정
+//        Star star = createStarEntity(requestDTO, userNode);
+//
+//        // 카테고리 관계 설정
+//        categoryCommandService.linkStarToCategory(star, starRequestDTO.getCategoryName());
+//
+//        // 키워드 생성 및 관계 설정
+//        keywordCommandService.linkStarToKeywords(star, starRequestDTO.getKeywordList());
+//
+//        // 키워드+ 카테고리 포함된 스타를 다시 조회
+//        Star savedStar = starRepository.findById(star.getId())
+//                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
+//
+//        // 스타 간 Link 노드 생성
+//        linkCommandService.createLinksForStar(savedStar);
+//
+//        return CreateStarResponseDTO.builder()
+//                .starId(star.getId())
+//                .title(star.getTitle())
+//                .categoryName(starRequestDTO.getCategoryName())
+//                .keywordList(savedStar.getKeywords().stream()
+//                        .map(Keyword::getName)
+//                        .collect(Collectors.toList()))
+//                .build();
+//
+//    }
+
     @Override
-    public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO){
-        CreateStarRequestDTO starRequestDTO = requestDTO.getStarRequestDTO();
+    public PutStarResponseDTO putStar(UUID starId, CreateStarRequestDTO requestDTO){
 
-        UserNode userNode = userNodeRepository.findById(user.getId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+        Star star = starRepository.findById(starId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
-        // 스타 생성 및 유저와 관계 설정
-        Star star = createStarEntity(requestDTO, userNode);
-
+        System.out.println("카테고리 이름" + requestDTO.getCategoryName());
         // 카테고리 관계 설정
-        categoryCommandService.linkStarToCategory(star, starRequestDTO.getCategoryName());
+        categoryCommandService.linkStarToCategory(star, requestDTO.getCategoryName());
 
         // 키워드 생성 및 관계 설정
-        keywordCommandService.linkStarToKeywords(star, starRequestDTO.getKeywordList());
+        keywordCommandService.linkStarToKeywords(star, requestDTO.getKeywordList());
 
         // 키워드+ 카테고리 포함된 스타를 다시 조회
         Star savedStar = starRepository.findById(star.getId())
@@ -93,42 +124,42 @@ public class StarCommandServiceImpl implements StarCommandService {
         // 스타 간 Link 노드 생성
         linkCommandService.createLinksForStar(savedStar);
 
-        return CreateStarResponseDTO.builder()
+        savedStar.updateStar(requestDTO.getThumbnailUrl(), requestDTO.getSummaryAI(), requestDTO.getUserMemo(), requestDTO.getEmbedding());
+
+        return PutStarResponseDTO.builder()
                 .starId(star.getId())
                 .title(star.getTitle())
-                .categoryName(starRequestDTO.getCategoryName())
+                .categoryName(requestDTO.getCategoryName())
                 .keywordList(savedStar.getKeywords().stream()
                         .map(Keyword::getName)
                         .collect(Collectors.toList()))
                 .build();
-
     }
 
-    public Star createStarEntity(CreateStarFileDTO requestDTO, UserNode userNode){
-        CreateStarRequestDTO starRequestDTO = requestDTO.getStarRequestDTO();
 
-        Star star = Star.builder()
-                .title(starRequestDTO.getTitle())
-                .siteUrl(starRequestDTO.getSiteUrl())
-                .thumbnailUrl(s3Service.saveThumbnail(requestDTO.getThumbnailImage(), starRequestDTO.getTitle()))
-                .htmlFileUrl(s3Service.saveHtmlFile(requestDTO.getHtmlFile(), starRequestDTO.getTitle()))
-                .summaryAI(starRequestDTO.getSummaryAI())
-                .userMemo(starRequestDTO.getUserMemo())
-                .views(0)
-                .embedding(starRequestDTO.getEmbedding())
-                .build();
-
-        Star savedStar = starRepository.save(star);
-        if (savedStar.getId() == null) {
-            throw new GeneralException(ErrorStatus._STAR_CREATION_FAILED);
-        }
-
-        // 유저 노드와 관계 설정 후 저장
-        userNode.getStars().add(savedStar);
-        userNodeRepository.save(userNode);
-
-        return savedStar;
-    }
+//    public Star createStarEntity(CreateStarFileDTO requestDTO, UserNode userNode){
+//        CreateStarRequestDTO starRequestDTO = requestDTO.getStarRequestDTO();
+//
+//        Star star = Star.builder()
+//                .thumbnailUrl(s3Service.saveThumbnail(requestDTO.getThumbnailImage(), starRequestDTO.getTitle()))
+//                .htmlFileUrl(s3Service.saveHtmlFile(requestDTO.getHtmlFile(), starRequestDTO.getTitle()))
+//                .summaryAI(starRequestDTO.getSummaryAI())
+//                .userMemo(starRequestDTO.getUserMemo())
+//                .views(0)
+//                .embedding(starRequestDTO.getEmbedding())
+//                .build();
+//
+//        Star savedStar = starRepository.save(star);
+//        if (savedStar.getId() == null) {
+//            throw new GeneralException(ErrorStatus._STAR_CREATION_FAILED);
+//        }
+//
+//        // 유저 노드와 관계 설정 후 저장
+//        userNode.getStars().add(savedStar);
+//        userNodeRepository.save(userNode);
+//
+//        return savedStar;
+//    }
 
     public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO){
         Star star = starRepository.findById(starId)

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -105,7 +105,7 @@ public class StarCommandServiceImpl implements StarCommandService {
 //    }
 
     @Override
-    public PutStarResponseDTO putStar(UUID starId, CreateStarRequestDTO requestDTO){
+    public PutStarResponseDTO updateStar(UUID starId, CreateStarRequestDTO requestDTO){
 
         Star star = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 public interface StarQueryService {
 
-    public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData);
+//    public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData);
 
     public GetStarListResponseDTO getStarList(Long userId);
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -15,9 +15,7 @@ import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,37 +29,37 @@ public class StarQueryServiceImpl implements StarQueryService {
     private final LinkQueryService linkQueryService;
 
     // 스타 JSON 데이터 파싱
-    @Override
-    public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData) {
-        ObjectMapper objectMapper = new ObjectMapper();
-
-        // LocalDateTime 처리
-        objectMapper.registerModule(new JavaTimeModule());
-
-        // 컨트롤문자 허용
-        objectMapper.configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature(), true);
-        // 작은따옴표 허용
-        objectMapper.configure(JsonReadFeature.ALLOW_SINGLE_QUOTES.mappedFeature(), true);
-        // \ 이스케이프 허용
-        objectMapper.configure(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER.mappedFeature(), true);
-
-        CreateStarRequestDTO request;
-        try {
-            // 유니코드 깨짐 방지
-            starJsonData = new String(starJsonData.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
-
-            request = objectMapper.readValue(starJsonData, CreateStarRequestDTO.class);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException("Invalid JSON format for starJsonData.");
-        }
-
-        return CreateStarFileDTO.builder()
-                .thumbnailImage(thumbnailImage)
-                .htmlFile(htmlFile)
-                .starRequestDTO(request)
-                .build();
-    }
+//    @Override
+//    public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData) {
+//        ObjectMapper objectMapper = new ObjectMapper();
+//
+//        // LocalDateTime 처리
+//        objectMapper.registerModule(new JavaTimeModule());
+//
+//        // 컨트롤문자 허용
+//        objectMapper.configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature(), true);
+//        // 작은따옴표 허용
+//        objectMapper.configure(JsonReadFeature.ALLOW_SINGLE_QUOTES.mappedFeature(), true);
+//        // \ 이스케이프 허용
+//        objectMapper.configure(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER.mappedFeature(), true);
+//
+//        CreateStarRequestDTO request;
+//        try {
+//            // 유니코드 깨짐 방지
+//            starJsonData = new String(starJsonData.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+//
+//            request = objectMapper.readValue(starJsonData, CreateStarRequestDTO.class);
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//            throw new RuntimeException("Invalid JSON format for starJsonData.");
+//        }
+//
+//        return CreateStarFileDTO.builder()
+//                .thumbnailImage(thumbnailImage)
+//                .htmlFile(htmlFile)
+//                .starRequestDTO(request)
+//                .build();
+//    }
 
 
     // 스타 + 링크 전체 조회

--- a/src/main/java/com/team_nebula/nebula/global/oauth/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/team_nebula/nebula/global/oauth/handler/CustomSuccessHandler.java
@@ -9,17 +9,15 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team_nebula.nebula.domain.user.entity.User;
 import com.team_nebula.nebula.domain.user.repository.mysql.UserRepository;
-import com.team_nebula.nebula.global.apipayload.ApiResponse;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import com.team_nebula.nebula.global.oauth.dto.CustomOAuth2User;
-import com.team_nebula.nebula.global.oauth.dto.TokenResponseDTO;
 import com.team_nebula.nebula.global.util.JWTUtil;
 
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -59,22 +57,18 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 		user.updateRefreshToken(refreshToken);
 		userRepository.save(user);
 
-		response.setContentType("application/json");
-		response.setCharacterEncoding("UTF-8");
+		response.addCookie(createCookie("Authorization", authorization));
+		response.addCookie(createCookie("refreshToken", refreshToken));
+		response.sendRedirect("http://localhost:3000/redirect");
+	}
 
-		TokenResponseDTO tokenResponse = TokenResponseDTO.builder()
-			.authorization(authorization)
-			.refreshToken(refreshToken)
-			.build();
+	private Cookie createCookie(String key, String value) {
+		Cookie cookie = new Cookie(key, value);
+		cookie.setMaxAge(60 * 60 * 60);
+		//cookie.setSecure(true);
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
 
-		ApiResponse<TokenResponseDTO> apiResponse = ApiResponse.onSuccess(tokenResponse);
-
-		ObjectMapper objectMapper = new ObjectMapper();
-		String jsonResponse = objectMapper.writeValueAsString(apiResponse);
-
-		response.getWriter().write(jsonResponse);
-		response.getWriter().flush();
-
-		// response.sendRedirect("http://localhost:3000/");
+		return cookie;
 	}
 }


### PR DESCRIPTION
## 💡 개요
스타 안에 데이터 수정 및 삭제(상태변경) + 스타 생성 플로우 분리

## 🔨작업 사항
### 1. 스타 수정
![image](https://github.com/user-attachments/assets/674ee0cf-dbb9-4bc0-9435-fa29855cbc64)
- 스타안에 카테고리, 제목, AI요약, 유저메모 데이터를 수정할 수 있음

![image](https://github.com/user-attachments/assets/4058f47e-e10f-4169-91e4-e76ec3a08a7d)
- updateStar 서비스단에서 카테고리 수정시 기존 카테고리와 연결된 관계를 삭제하고 수정된 카테고리로 관계 연결함

### 2. 스타 삭제
- Star 프로퍼티에 isDeletedStatus를 추가했고 스타 노드 생성시에 false로 저장됨
- 삭제 시 상태가 true로 변경됨

### 3. 스타 생성 플로우 수정
![image](https://github.com/user-attachments/assets/b8b7465e-2db6-45a8-ae00-3bfbcde9a97c)
- 기존 기능은 스타 생성할때 모든 데이터를 저장했지만 익스텐션에서 제목, 사이트주소, html파일만 저장하는 스타 노드를 생성 후 사용자가 데이터를 입력 한 후 저장하면 PATCH로 스타노드가 수정됨
- 처음 스타 노드 생성할때는 유저 노드와 관계만 연결
- 나중에 데이터 입력시, 카테고리, 키워드, 링크 생성 및 관계 연결 실시

## 📝 기타 (선택)
- 추후에 스타 조회 기능에서 isDeletedStatus가 false인 스타만 조회하는 조건으로 수정
- 익스텐션에서 취소하기 한 경우 스타 노드를 삭제하는 기능을 추가적으로 구현할 예정