### PR TITLE
SCRUM 146 : 카테고리 수정 및 삭제 기능 구현

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/category/api/CategoryController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/api/CategoryController.java
@@ -3,6 +3,7 @@ package com.team_nebula.nebula.domain.category.api;
 import com.team_nebula.nebula.domain.category.dto.request.CreateCategoryRequestDTO;
 import com.team_nebula.nebula.domain.category.dto.request.UpdateCategoryOneRequestDTO;
 import com.team_nebula.nebula.domain.category.dto.response.CreateCategoryResponseDTO;
+import com.team_nebula.nebula.domain.category.dto.response.DeleteCategoryResponseDTO;
 import com.team_nebula.nebula.domain.category.dto.response.GetCategoryListResponseDTO;
 import com.team_nebula.nebula.domain.category.dto.response.UpdateCategoryOneResponseDTO;
 import com.team_nebula.nebula.domain.category.service.CategoryCommandService;
@@ -45,6 +46,12 @@ public class CategoryController {
     @PatchMapping("{categoryId}")
     public ApiResponse<UpdateCategoryOneResponseDTO> updateCategory(@RequestBody UpdateCategoryOneRequestDTO requestDTO, @PathVariable UUID categoryId) {
         UpdateCategoryOneResponseDTO responseDTO = categoryCommandService.updateCategory(requestDTO, categoryId);
+        return ApiResponse.onSuccess(responseDTO);
+    }
+
+    @PatchMapping("/{categoryId}/deactivate")
+    public ApiResponse<DeleteCategoryResponseDTO> deleteCategory(@AuthUser User user, @PathVariable UUID categoryId){
+        DeleteCategoryResponseDTO responseDTO = categoryCommandService.deleteCategory(user.getId(), categoryId);
         return ApiResponse.onSuccess(responseDTO);
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/category/api/CategoryController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/api/CategoryController.java
@@ -1,8 +1,10 @@
 package com.team_nebula.nebula.domain.category.api;
 
 import com.team_nebula.nebula.domain.category.dto.request.CreateCategoryRequestDTO;
+import com.team_nebula.nebula.domain.category.dto.request.UpdateCategoryOneRequestDTO;
 import com.team_nebula.nebula.domain.category.dto.response.CreateCategoryResponseDTO;
 import com.team_nebula.nebula.domain.category.dto.response.GetCategoryListResponseDTO;
+import com.team_nebula.nebula.domain.category.dto.response.UpdateCategoryOneResponseDTO;
 import com.team_nebula.nebula.domain.category.service.CategoryCommandService;
 import com.team_nebula.nebula.domain.category.service.CategoryQueryService;
 import com.team_nebula.nebula.domain.user.entity.User;
@@ -12,6 +14,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,6 +39,13 @@ public class CategoryController {
     public ApiResponse<GetCategoryListResponseDTO> getCategoryList(@AuthUser User user) {
         GetCategoryListResponseDTO responseDto = categoryQueryService.getCategoryList(user.getId());
         return ApiResponse.onSuccess(responseDto);
+    }
+
+    // 카테고리 이름 수정 API
+    @PatchMapping("{categoryId}")
+    public ApiResponse<UpdateCategoryOneResponseDTO> updateCategory(@RequestBody UpdateCategoryOneRequestDTO requestDTO, @PathVariable UUID categoryId) {
+        UpdateCategoryOneResponseDTO responseDTO = categoryCommandService.updateCategory(requestDTO, categoryId);
+        return ApiResponse.onSuccess(responseDTO);
     }
 }
 

--- a/src/main/java/com/team_nebula/nebula/domain/category/dto/request/UpdateCategoryOneRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/dto/request/UpdateCategoryOneRequestDTO.java
@@ -1,0 +1,8 @@
+package com.team_nebula.nebula.domain.category.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateCategoryOneRequestDTO {
+    private String newName;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/category/dto/response/DeleteCategoryResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/dto/response/DeleteCategoryResponseDTO.java
@@ -1,0 +1,17 @@
+package com.team_nebula.nebula.domain.category.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeleteCategoryResponseDTO {
+    private UUID categoryId;
+    private String deleteStatus;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/category/dto/response/UpdateCategoryOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/dto/response/UpdateCategoryOneResponseDTO.java
@@ -1,0 +1,15 @@
+package com.team_nebula.nebula.domain.category.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateCategoryOneResponseDTO {
+    private String newName;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/category/entity/Category.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/entity/Category.java
@@ -30,4 +30,6 @@ public class Category extends BaseEntity {
         this.id = UUID.randomUUID();
         this.name = name;
     }
+
+    public void updateName(String name) {this.name = name;}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/category/entity/Category.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/entity/Category.java
@@ -22,6 +22,9 @@ public class Category extends BaseEntity {
     @Property(name = "name")
     private String name;
 
+    @Property("Deleted status")
+    private Boolean isDeletedStatus;
+
     @Relationship(type = "BELONGS_TO", direction = Relationship.Direction.INCOMING)
     private Set<Star> stars = new HashSet<>();
 
@@ -29,7 +32,10 @@ public class Category extends BaseEntity {
     public Category(String name) {
         this.id = UUID.randomUUID();
         this.name = name;
+        this.isDeletedStatus = false;
     }
 
     public void updateName(String name) {this.name = name;}
+
+    public void updateIsDeletedStatus() {this.isDeletedStatus = true;}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/repository/CategoryRepository.java
@@ -16,6 +16,7 @@ public interface CategoryRepository extends Neo4jRepository<Category, UUID> {
 
     @Query("""
     MATCH (u:UserNode {userId: $userId})-[:GENERATED]->(c:Category)
+    WHERE c.isDeletedStatus = false OR c.isDeletedStatus IS NULL
     OPTIONAL MATCH (c)<-[:BELONGS_TO]-(s:Star)
     RETURN c.id AS id, c.name AS name, COUNT(s) AS includedStarCnt
     """)

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandService.java
@@ -1,8 +1,12 @@
 package com.team_nebula.nebula.domain.category.service;
 
 import com.team_nebula.nebula.domain.category.dto.request.CreateCategoryRequestDTO;
+import com.team_nebula.nebula.domain.category.dto.request.UpdateCategoryOneRequestDTO;
 import com.team_nebula.nebula.domain.category.dto.response.CreateCategoryResponseDTO;
+import com.team_nebula.nebula.domain.category.dto.response.UpdateCategoryOneResponseDTO;
 import com.team_nebula.nebula.domain.star.entity.Star;
+
+import java.util.UUID;
 
 public interface CategoryCommandService {
 
@@ -11,5 +15,7 @@ public interface CategoryCommandService {
     public void linkStarToCategory(Star star, String categoryName);
 
     public String linkStarToCategoryAndGetName(Star star, String categoryName);
+
+    public UpdateCategoryOneResponseDTO updateCategory(UpdateCategoryOneRequestDTO requestDTO, UUID categoryId);
 
     }

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandService.java
@@ -3,6 +3,7 @@ package com.team_nebula.nebula.domain.category.service;
 import com.team_nebula.nebula.domain.category.dto.request.CreateCategoryRequestDTO;
 import com.team_nebula.nebula.domain.category.dto.request.UpdateCategoryOneRequestDTO;
 import com.team_nebula.nebula.domain.category.dto.response.CreateCategoryResponseDTO;
+import com.team_nebula.nebula.domain.category.dto.response.DeleteCategoryResponseDTO;
 import com.team_nebula.nebula.domain.category.dto.response.UpdateCategoryOneResponseDTO;
 import com.team_nebula.nebula.domain.star.entity.Star;
 
@@ -18,4 +19,6 @@ public interface CategoryCommandService {
 
     public UpdateCategoryOneResponseDTO updateCategory(UpdateCategoryOneRequestDTO requestDTO, UUID categoryId);
 
-    }
+    public DeleteCategoryResponseDTO deleteCategory(Long userId, UUID categoryId);
+
+}

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
@@ -1,7 +1,9 @@
 package com.team_nebula.nebula.domain.category.service;
 
 import com.team_nebula.nebula.domain.category.dto.request.CreateCategoryRequestDTO;
+import com.team_nebula.nebula.domain.category.dto.request.UpdateCategoryOneRequestDTO;
 import com.team_nebula.nebula.domain.category.dto.response.CreateCategoryResponseDTO;
+import com.team_nebula.nebula.domain.category.dto.response.UpdateCategoryOneResponseDTO;
 import com.team_nebula.nebula.domain.category.entity.Category;
 import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
 import com.team_nebula.nebula.domain.star.entity.Star;
@@ -12,6 +14,8 @@ import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 
 @Service
@@ -67,6 +71,21 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
         String cname = categoryRepository.findNameByStarAndRemoveRelation(star.getId(), categoryName);
 
         return cname;
+    }
+
+    @Override
+    public UpdateCategoryOneResponseDTO updateCategory(UpdateCategoryOneRequestDTO requestDTO, UUID categoryId){
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CATEGORY_NOT_FOUND));
+
+        String newName = requestDTO.getNewName();
+
+        category.updateName(newName);
+        categoryRepository.save(category);
+
+        return UpdateCategoryOneResponseDTO.builder()
+                .newName(category.getName())
+                .build();
     }
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/service/CategoryCommandServiceImpl.java
@@ -3,6 +3,7 @@ package com.team_nebula.nebula.domain.category.service;
 import com.team_nebula.nebula.domain.category.dto.request.CreateCategoryRequestDTO;
 import com.team_nebula.nebula.domain.category.dto.request.UpdateCategoryOneRequestDTO;
 import com.team_nebula.nebula.domain.category.dto.response.CreateCategoryResponseDTO;
+import com.team_nebula.nebula.domain.category.dto.response.DeleteCategoryResponseDTO;
 import com.team_nebula.nebula.domain.category.dto.response.UpdateCategoryOneResponseDTO;
 import com.team_nebula.nebula.domain.category.entity.Category;
 import com.team_nebula.nebula.domain.category.repository.CategoryRepository;
@@ -78,6 +79,12 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
         Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._CATEGORY_NOT_FOUND));
 
+        // 카테고리 중복 여부 체크
+        boolean categoryExists = categoryRepository.existsByName(requestDTO.getNewName());
+        if (categoryExists) {
+            throw new GeneralException(ErrorStatus._CATEGORY_ALREADY_EXIST);
+        }
+
         String newName = requestDTO.getNewName();
 
         category.updateName(newName);
@@ -85,6 +92,24 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
 
         return UpdateCategoryOneResponseDTO.builder()
                 .newName(category.getName())
+                .build();
+    }
+
+    @Override
+    public DeleteCategoryResponseDTO deleteCategory(Long userId, UUID categoryId){
+        UserNode userNode = userNodeRepository.findByUserId(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CATEGORY_NOT_FOUND));
+
+        category.updateIsDeletedStatus();
+        categoryRepository.save(category);
+
+        String deleteMessage = "Category : " + category.getName() + " was deleted";
+        return DeleteCategoryResponseDTO.builder()
+                .categoryId(categoryId)
+                .deleteStatus(deleteMessage)
                 .build();
     }
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -99,7 +99,7 @@ public class StarController {
     }
 
     // 스타 삭제 API
-    @PatchMapping("/delete/{starId}")
+    @PatchMapping("/{starId}/deactivate")
     public ApiResponse<DeleteStarResponseDTO> deleteStar(@AuthUser User user, @PathVariable UUID starId){
         DeleteStarResponseDTO responseDTO = starCommandService.deleteStar(starId);
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -38,10 +38,10 @@ public class StarController {
         return ApiResponse.onSuccessCreated(responseDTO);
     }
 
-    // 스타 수정 API(데이터 입력 후 나머지 노드 생성)
+    // 스타 입력 완료 API(데이터 입력 후 나머지 노드 생성)
     @PatchMapping("/complete/{starId}")
-    public ApiResponse<PutStarResponseDTO> updateStar(@PathVariable UUID starId, @RequestBody CreateStarRequestDTO requestDTO){
-        PutStarResponseDTO responseDTO = starCommandService.updateStar(starId, requestDTO);
+    public ApiResponse<PutStarResponseDTO> createCompleteStar(@PathVariable UUID starId, @RequestBody CreateStarRequestDTO requestDTO){
+        PutStarResponseDTO responseDTO = starCommandService.createCompleteStar(starId, requestDTO);
 
         return ApiResponse.onSuccess(responseDTO);
     }
@@ -89,7 +89,7 @@ public class StarController {
 
     // 스타 수정 API
     @PatchMapping("/{starId}")
-    public ApiResponse<GetStarOneResponseDTO> updateStar(
+    public ApiResponse<GetStarOneResponseDTO> createCompleteStar(
             @PathVariable UUID starId,
             @RequestBody UpdateStarOneRequestDTO requestDTO
     ){

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -17,7 +17,7 @@ public interface StarCommandService {
 
 //    public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO);
 
-    public PutStarResponseDTO updateStar(UUID starId, CreateStarRequestDTO requestDTO);
+    public PutStarResponseDTO createCompleteStar(UUID starId, CreateStarRequestDTO requestDTO);
 
     public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO);
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -7,7 +7,6 @@ import com.team_nebula.nebula.domain.image.S3Service;
 import com.team_nebula.nebula.domain.keyword.entity.Keyword;
 import com.team_nebula.nebula.domain.keyword.service.KeywordCommandService;
 import com.team_nebula.nebula.domain.link.service.LinkCommandService;
-import com.team_nebula.nebula.domain.star.converter.StarConverter;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
@@ -35,7 +34,6 @@ import java.util.stream.Collectors;
 public class StarCommandServiceImpl implements StarCommandService {
 
     private final StarRepository starRepository;
-    private final CategoryRepository categoryRepository;
     private final UserNodeRepository userNodeRepository;
     private final CategoryCommandService categoryCommandService;
     private final CategoryQueryService categoryQueryService;

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -8,7 +8,6 @@ import com.team_nebula.nebula.domain.keyword.entity.Keyword;
 import com.team_nebula.nebula.domain.keyword.service.KeywordCommandService;
 import com.team_nebula.nebula.domain.link.service.LinkCommandService;
 import com.team_nebula.nebula.domain.star.converter.StarConverter;
-import com.team_nebula.nebula.domain.star.dto.request.CreateStarFileDTO;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
@@ -105,12 +104,11 @@ public class StarCommandServiceImpl implements StarCommandService {
 //    }
 
     @Override
-    public PutStarResponseDTO updateStar(UUID starId, CreateStarRequestDTO requestDTO){
+    public PutStarResponseDTO createCompleteStar(UUID starId, CreateStarRequestDTO requestDTO){
 
         Star star = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
-        System.out.println("카테고리 이름" + requestDTO.getCategoryName());
         // 카테고리 관계 설정
         categoryCommandService.linkStarToCategory(star, requestDTO.getCategoryName());
 


### PR DESCRIPTION
## 💡 개요
카테고리 이름 수정 및 soft delete 기능을 구현 + 조회 기능 수정

## 🔨작업 사항
### 1. 카테고리 수정
- 카테고리 이름을 받아서 대체함

### 2. 카테고리 삭제
- 삭제 하면 isDeletedStatus 가 false에서 true로 바뀜

### 3. 카테고리 조회 기능 수정
```
@Query("""
    MATCH (u:UserNode {userId: $userId})-[:GENERATED]->(c:Category)
    WHERE c.isDeletedStatus = false OR c.isDeletedStatus IS NULL
    OPTIONAL MATCH (c)<-[:BELONGS_TO]-(s:Star)
    RETURN c.id AS id, c.name AS name, COUNT(s) AS includedStarCnt
    """)
    List<GetCategoryOneResponseDTO> findUserCategoriesWithStarCount(@Param("userId") Long userId);
```
- where절을 통해 삭제안된 카테고리만 조회하는 것으로 수정

## 📝 기타 (선택)
- 처음부터 설계할때 soft delete하기로 생각을 했어야했음 this is my fault