### PR TITLE
SCRUM152 :  스타 생성 취소 기능 구현 + 스타 조회 기능 수정

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/category/api/CategoryController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/category/api/CategoryController.java
@@ -11,6 +11,7 @@ import com.team_nebula.nebula.domain.category.service.CategoryQueryService;
 import com.team_nebula.nebula.domain.user.entity.User;
 import com.team_nebula.nebula.global.annotation.AuthUser;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class CategoryController {
     private final CategoryQueryService categoryQueryService;
 
     // 카데고리 생성 API
+    @Operation(summary = "카테고리 생성", description = "새로운 카테고리를 생성하는 API / {name: string} 이렇게만 보내도 가능합니다. 지금 스웨거에 있는 JSON 방식은 무시해도됨")
     @PostMapping
     public ApiResponse<CreateCategoryResponseDTO> createCategory(@AuthUser User user,
         @RequestBody @Valid CreateCategoryRequestDTO request) {
@@ -36,6 +38,7 @@ public class CategoryController {
     }
 
     // 카테고리 전체 조회 API
+    @Operation(summary = "카테고리 전체 조회", description = "사용자의 모든 카테고리를 조회하는 API")
     @GetMapping
     public ApiResponse<GetCategoryListResponseDTO> getCategoryList(@AuthUser User user) {
         GetCategoryListResponseDTO responseDto = categoryQueryService.getCategoryList(user.getId());
@@ -43,12 +46,15 @@ public class CategoryController {
     }
 
     // 카테고리 이름 수정 API
+    @Operation(summary = "카테고리 이름 수정", description = "특정 카테고리의 이름을 수정하는 API")
     @PatchMapping("{categoryId}")
     public ApiResponse<UpdateCategoryOneResponseDTO> updateCategory(@RequestBody UpdateCategoryOneRequestDTO requestDTO, @PathVariable UUID categoryId) {
         UpdateCategoryOneResponseDTO responseDTO = categoryCommandService.updateCategory(requestDTO, categoryId);
         return ApiResponse.onSuccess(responseDTO);
     }
 
+    // 카테고리 삭제
+    @Operation(summary = "카테고리 삭제", description = "특정 카테고리를 비활성화(삭제)하는 API")
     @PatchMapping("/{categoryId}/deactivate")
     public ApiResponse<DeleteCategoryResponseDTO> deleteCategory(@AuthUser User user, @PathVariable UUID categoryId){
         DeleteCategoryResponseDTO responseDTO = categoryCommandService.deleteCategory(user.getId(), categoryId);

--- a/src/main/java/com/team_nebula/nebula/domain/image/S3Service.java
+++ b/src/main/java/com/team_nebula/nebula/domain/image/S3Service.java
@@ -1,7 +1,9 @@
 package com.team_nebula.nebula.domain.image;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
@@ -31,6 +33,7 @@ public class S3Service {
 
     private static final String THUMBNAIL_DIR = "thumbnails/";
     private static final String HTML_FILE_DIR = "html_files/";
+
 
     public String saveThumbnail(MultipartFile thumbnailImage, String dataInfo) {
         return uploadThumbnailToS3(thumbnailImage, THUMBNAIL_DIR, dataInfo);
@@ -100,6 +103,17 @@ public class S3Service {
             log.error("File conversion failed: {}", e.getMessage());
         }
         return Optional.empty();
+    }
+
+    public void deleteHtmlFileInS3(String fileKey){
+        try{
+            amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, fileKey));
+            log.info("Deleted HTML file from S3: {}", fileKey);
+        }
+        catch(AmazonServiceException e){
+            log.error("Failed to delete HTML file from S3: {}", fileKey, e);
+            throw new GeneralException(ErrorStatus._S3_HTML_FILE_DELETE_FAIL);
+        }
     }
 }
 

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -15,6 +15,8 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
     @Query("""
         MATCH (s1:Star)-[:TAGGED]->(k:Keyword)<-[:TAGGED]-(s2:Star)
         WHERE s1.id = $starId AND s1 <> s2
+        AND (s1.isDeletedStatus = false OR s1.isDeletedStatus IS NULL)
+        AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
         WITH s1, s2, COUNT(k) AS sharedKeywordNum
         WHERE sharedKeywordNum > 0
         MERGE (l:Link {linked_two_node_Id: [s1.id, s2.id]})
@@ -26,7 +28,7 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)
-    WHERE u.userId = $userId
+    WHERE u.userId = $userId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
 
     MATCH (s)-[:LINKED]->(l:Link)
     WHERE EXISTS {
@@ -43,7 +45,7 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:BELONGS_TO]->(c:Category)
-    WHERE u.userId = $userId AND c.id = $categoryId
+    WHERE u.userId = $userId AND c.id = $categoryId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
     
     MATCH (s)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
     WHERE (u)-[:CREATED]->(s2)
@@ -57,7 +59,7 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:TAGGED]->(k:Keyword)
-    WHERE u.userId = $userId AND k.name = $keywordId
+    WHERE u.userId = $userId AND k.name = $keywordId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
     
     MATCH (s)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
     WHERE (u)-[:CREATED]->(s2)

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -8,6 +8,7 @@ import com.team_nebula.nebula.domain.star.service.StarQueryService;
 import com.team_nebula.nebula.domain.user.entity.User;
 import com.team_nebula.nebula.global.annotation.AuthUser;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -26,6 +27,7 @@ public class StarController {
     private final StarQueryService starQueryService;
 
     // 스타 생성 API(크롬 익스텐션에서 추가하는 경우)
+    @Operation(summary = "스타 생성", description = "크롬 익스텐션에서 북마크(스타)를 생성하는 API / 현재 스타가 생성되면 중복된 키워드 기준으로 링크 생성여부가 결정됨, 스타간 유사도는 아직 노력중")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<CreateStarResponseDTO> createStar(
             @AuthUser User user,
@@ -39,6 +41,7 @@ public class StarController {
     }
 
     // 스타 입력 완료 API(데이터 입력 후 나머지 노드 생성)
+    @Operation(summary = "스타 입력 완료", description = "스타의 카테고리, 사용자메모, AI요약, 키워드를 입력하고 스타 정보 입력을 완료하는 API")
     @PatchMapping("/complete/{starId}")
     public ApiResponse<PutStarResponseDTO> createCompleteStar(@PathVariable UUID starId, @RequestBody CreateStarRequestDTO requestDTO){
         PutStarResponseDTO responseDTO = starCommandService.createCompleteStar(starId, requestDTO);
@@ -47,6 +50,7 @@ public class StarController {
     }
 
     // 스타 전체 조회 API
+    @Operation(summary = "스타 전체 조회", description = "사용자의 모든 스타를 조회하는 API")
     @GetMapping
     public ApiResponse<GetStarListResponseDTO> getStarList(@AuthUser User user){
         GetStarListResponseDTO responseDTO = starQueryService.getStarList(user.getId());
@@ -55,6 +59,7 @@ public class StarController {
     }
 
     // 스타 단일 조회 API
+    @Operation(summary = "스타 단일 조회", description = "특정 스타 정보를 조회하는 API로 이 API를 실행하면 views(조회수)가 1증가함")
     @GetMapping("/{starId}")
     public ApiResponse<GetStarOneResponseDTO> getStarOne(@PathVariable UUID starId){
         GetStarOneResponseDTO responseDTO = starQueryService.getStarOne(starId);
@@ -63,6 +68,7 @@ public class StarController {
     }
 
     // 카테고리별 스타 조회 API
+    @Operation(summary = "카테고리별 스타 조회", description = "특정 카테고리에 속한 스타들을 조회하는 API")
     @GetMapping("/categories/{categoryId}")
     public ApiResponse<GetStarListResponseDTO> getStarListByCategory(@AuthUser User user, @PathVariable UUID categoryId){
         GetStarListResponseDTO responseDTO = starQueryService.getStarListInCategory(user.getId(), categoryId);
@@ -71,6 +77,7 @@ public class StarController {
     }
 
     // 키워드별 스타 조회 API
+    @Operation(summary = "키워드별 스타 조회", description = "특정 키워드가 포함된 스타들을 조회하는 API")
     @GetMapping("/keywords/{keywordId}")
     public ApiResponse<GetStarListResponseDTO> getStarListByKeyword(@AuthUser User user, @PathVariable String keywordId){
         System.out.println("KeywordId: " + keywordId);
@@ -80,6 +87,7 @@ public class StarController {
     }
 
     // 스타 검색 API
+    @Operation(summary = "스타 검색", description = "title(제목)을 기준으로 스타를 검색하는 API")
     @GetMapping("/search")
     public ApiResponse<GetSearchedStarListResponseDTO> searchStar(@RequestParam String title, @AuthUser User user){
         GetSearchedStarListResponseDTO responseDTO = starQueryService.searchStars(user.getId(), title);
@@ -88,6 +96,7 @@ public class StarController {
     }
 
     // 스타 수정 API
+    @Operation(summary = "스타 정보 수정", description = "특정 스타 정보를 수정하는 API / title(제목), categoryName(카테고리), summaryAI(AI요약), userMemo(사용자메모)를 각각 수정할 수 있음")
     @PatchMapping("/{starId}")
     public ApiResponse<GetStarOneResponseDTO> createCompleteStar(
             @PathVariable UUID starId,
@@ -99,6 +108,7 @@ public class StarController {
     }
 
     // 스타 삭제 API
+    @Operation(summary = "스타 삭제", description = "스타를 비활성화하는 API/ 완전 삭제가 아닌 Soft Delete하는 것")
     @PatchMapping("/{starId}/deactivate")
     public ApiResponse<DeleteStarResponseDTO> deleteStar(@AuthUser User user, @PathVariable UUID starId){
         DeleteStarResponseDTO responseDTO = starCommandService.deleteStar(starId);
@@ -107,6 +117,7 @@ public class StarController {
     }
 
     // 스타화 취소 API
+    @Operation(summary = "스타화 취소", description = "스타 등록을 취소하는 API / 크롬 익스텐션에서 북마크 추가하기를 누르고 넘어가는 화면에서 저장 말고 취소를 눌렀을때 스타를 완전 삭제하는 기능")
     @DeleteMapping("/{starId}/cancel")
     public ApiResponse<DeleteStarResponseDTO> cancelStar(@PathVariable UUID starId, @AuthUser User user){
         DeleteStarResponseDTO responseDTO = starCommandService.cancelStar(starId);

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -105,4 +105,12 @@ public class StarController {
 
         return ApiResponse.onSuccess(responseDTO);
     }
+
+    // 스타화 취소 API
+    @DeleteMapping("/{starId}/cancel")
+    public ApiResponse<DeleteStarResponseDTO> cancelStar(@PathVariable UUID starId, @AuthUser User user){
+        DeleteStarResponseDTO responseDTO = starCommandService.cancelStar(starId);
+
+        return ApiResponse.onSuccess(responseDTO);
+    }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/converter/StarConverter.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/converter/StarConverter.java
@@ -57,7 +57,7 @@ public class StarConverter {
 public static GetSearchedStarListResponseDTO convertToStarListDto(List<GetSearchedStarOneResponseDTO> queryResult) {
     if (queryResult == null || queryResult.isEmpty()) {
         return GetSearchedStarListResponseDTO.builder()
-                .type("검새된 스타 - 링크 - 검색된 스타와 직접 연결된 스타")
+                .type("검색된 스타 - 링크 - 검색된 스타와 직접 연결된 스타")
                 .totalStarCnt(0)
                 .totalLinkCnt(0)
                 .searchedStarListDto(Collections.emptyList())

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
@@ -16,7 +16,6 @@ public class CreateStarRequestDTO {
     private String thumbnailUrl;
     private String summaryAI;
     private String userMemo;
-    private String embedding;
     private String categoryName;
     private List<String> keywordList;
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/entity/Star.java
@@ -46,9 +46,7 @@ public class Star extends BaseEntity {
     @Property("html_file_url")
     private String htmlFileUrl;
 
-    private String embedding;
-
-    @Property("Deleted status")
+    @Property("isDeletedStatus")
     private Boolean isDeletedStatus;
 
     @Relationship(type = "LINKED", direction = Relationship.Direction.OUTGOING)
@@ -59,7 +57,7 @@ public class Star extends BaseEntity {
 
     @Builder
     public Star(String title, String siteUrl, String thumbnailUrl, String summaryAI, String userMemo, int views,
-                String htmlFileUrl, String embedding) {
+                String htmlFileUrl) {
         this.id = UUID.randomUUID();
         this.title = title;
         this.siteUrl = siteUrl;
@@ -68,15 +66,13 @@ public class Star extends BaseEntity {
         this.userMemo = userMemo;
         this.views = views;
         this.htmlFileUrl = htmlFileUrl;
-        this.embedding = embedding;
         this.isDeletedStatus = false;
     }
 
-    public void updateStar(String thumbnailUrl, String summaryAI, String userMemo, String embedding) {
+    public void updateStar(String thumbnailUrl, String summaryAI, String userMemo) {
         this.thumbnailUrl = thumbnailUrl;
         this.summaryAI = summaryAI;
         this.userMemo = userMemo;
-        this.embedding = embedding;
         this.isDeletedStatus = false;
     }
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 public interface StarRepository extends Neo4jRepository<Star, UUID> {
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)
-    WHERE u.userId = $userId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
+    WHERE u.userId = $userId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL
     OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
     OPTIONAL MATCH (s)-[:BELONGS_TO]->(c:Category)
     RETURN s.id AS starId,

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 public interface StarRepository extends Neo4jRepository<Star, UUID> {
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)
-    WHERE u.userId = $userId
+    WHERE u.userId = $userId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
     OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
     OPTIONAL MATCH (s)-[:BELONGS_TO]->(c:Category)
     RETURN s.id AS starId,
@@ -32,6 +32,7 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
     @Query("""
         MATCH (s:Star {id: $starId})-[:BELONGS_TO]->(c:Category)
         OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
+        WHERE s.isDeletedStatus = false OR s.isDeletedStatus IS NULL
     
         RETURN s.id AS starId,
                s.title AS title,
@@ -47,23 +48,23 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:BELONGS_TO]->(c:Category)
-    WHERE u.userId = $userId AND c.id = $categoryId
+    WHERE u.userId = $userId AND c.id = $categoryId AND (isDeletedStatus = false OR s.isDeletedStatus IS NULL)
     OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
-    RETURN s.id AS starId, 
-           s.title AS title, 
-           s.siteUrl AS siteUrl, 
-           s.thumbnailUrl AS thumbnailUrl, 
-           s.summaryAI AS summaryAI, 
-           s.userMemo AS userMemo, 
-           s.views AS views, 
-           c.name AS categoryName, 
+    RETURN s.id AS starId,
+           s.title AS title,
+           s.siteUrl AS siteUrl,
+           s.thumbnailUrl AS thumbnailUrl,
+           s.summaryAI AS summaryAI,
+           s.userMemo AS userMemo,
+           s.views AS views,
+           c.name AS categoryName,
            COLLECT(k.name) AS keywordList
     """)
     List<GetStarOneResponseDTO> findStarsInCategory(@Param("userId") Long userId, @Param("categoryId") UUID categoryId);
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:TAGGED]->(k:Keyword)
-    WHERE u.userId = $userId AND k.name = $keywordId
+    WHERE u.userId = $userId AND k.name = $keywordId AND (isDeletedStatus = false OR s.isDeletedStatus IS NULL)
     OPTIONAL MATCH (s)-[:BELONGS_TO]->(c:Category)
     RETURN s.id AS starId,
            s.title AS title,
@@ -81,6 +82,7 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
     MATCH (u:UserNode)-[:CREATED]->(s:Star)
     WHERE u.userId = $userId
       AND ($title IS NULL OR toLower(s.title) CONTAINS toLower($title))
+      AND (isDeletedStatus = false OR s.isDeletedStatus IS NULL)
 
     OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
     OPTIONAL MATCH (s)-[:BELONGS_TO]->(c:Category)

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
@@ -48,7 +48,7 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:BELONGS_TO]->(c:Category)
-    WHERE u.userId = $userId AND c.id = $categoryId AND (isDeletedStatus = false OR s.isDeletedStatus IS NULL)
+    WHERE u.userId = $userId AND c.id = $categoryId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
     OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
     RETURN s.id AS starId,
            s.title AS title,
@@ -64,7 +64,7 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:TAGGED]->(k:Keyword)
-    WHERE u.userId = $userId AND k.name = $keywordId AND (isDeletedStatus = false OR s.isDeletedStatus IS NULL)
+    WHERE u.userId = $userId AND k.name = $keywordId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
     OPTIONAL MATCH (s)-[:BELONGS_TO]->(c:Category)
     RETURN s.id AS starId,
            s.title AS title,
@@ -82,7 +82,7 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
     MATCH (u:UserNode)-[:CREATED]->(s:Star)
     WHERE u.userId = $userId
       AND ($title IS NULL OR toLower(s.title) CONTAINS toLower($title))
-      AND (isDeletedStatus = false OR s.isDeletedStatus IS NULL)
+      AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
 
     OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
     OPTIONAL MATCH (s)-[:BELONGS_TO]->(c:Category)

--- a/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/repository/StarRepository.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 public interface StarRepository extends Neo4jRepository<Star, UUID> {
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)
-    WHERE u.userId = $userId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL
+    WHERE u.userId = $userId AND s.isDeletedStatus = false
     OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
     OPTIONAL MATCH (s)-[:BELONGS_TO]->(c:Category)
     RETURN s.id AS starId,
@@ -32,7 +32,7 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
     @Query("""
         MATCH (s:Star {id: $starId})-[:BELONGS_TO]->(c:Category)
         OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
-        WHERE s.isDeletedStatus = false OR s.isDeletedStatus IS NULL
+        WHERE s.isDeletedStatus = false
     
         RETURN s.id AS starId,
                s.title AS title,
@@ -48,7 +48,7 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:BELONGS_TO]->(c:Category)
-    WHERE u.userId = $userId AND c.id = $categoryId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
+    WHERE u.userId = $userId AND c.id = $categoryId AND s.isDeletedStatus = false
     OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
     RETURN s.id AS starId,
            s.title AS title,
@@ -64,7 +64,7 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)-[:TAGGED]->(k:Keyword)
-    WHERE u.userId = $userId AND k.name = $keywordId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
+    WHERE u.userId = $userId AND k.name = $keywordId AND s.isDeletedStatus = false
     OPTIONAL MATCH (s)-[:BELONGS_TO]->(c:Category)
     RETURN s.id AS starId,
            s.title AS title,
@@ -82,7 +82,7 @@ public interface StarRepository extends Neo4jRepository<Star, UUID> {
     MATCH (u:UserNode)-[:CREATED]->(s:Star)
     WHERE u.userId = $userId
       AND ($title IS NULL OR toLower(s.title) CONTAINS toLower($title))
-      AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
+      AND s.isDeletedStatus = false
 
     OPTIONAL MATCH (s)-[:TAGGED]->(k:Keyword)
     OPTIONAL MATCH (s)-[:BELONGS_TO]->(c:Category)

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -22,4 +22,6 @@ public interface StarCommandService {
     public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO);
 
     public DeleteStarResponseDTO deleteStar(UUID starId);
+
+    public DeleteStarResponseDTO cancelStar(UUID starId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -135,7 +135,7 @@ public class StarCommandServiceImpl implements StarCommandService {
         // 스타 간 Link 노드 생성
         linkCommandService.createLinksForStar(savedStar);
 
-        savedStar.updateStar(requestDTO.getThumbnailUrl(), requestDTO.getSummaryAI(), requestDTO.getUserMemo(), requestDTO.getEmbedding());
+        savedStar.updateStar(requestDTO.getThumbnailUrl(), requestDTO.getSummaryAI(), requestDTO.getUserMemo());
 
         return PutStarResponseDTO.builder()
                 .starId(star.getId())

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -229,4 +229,19 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .build();
     }
 
+    @Override
+    public DeleteStarResponseDTO cancelStar(UUID starId){
+        Star star = starRepository.findById(starId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
+
+        s3Service.deleteHtmlFileInS3(star.getHtmlFileUrl());
+        starRepository.delete(star);
+
+        String canceledMessage = "Star with ID : " + starId + " was completely deleted";
+        return DeleteStarResponseDTO.builder()
+                .starId(starId)
+                .deleteStatus(canceledMessage)
+                .build();
+    }
+
 }

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -30,7 +30,9 @@ public enum ErrorStatus implements BaseErrorCode {
 	_MULTIPARTFILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,"MULTIPARTFILE5000","MultipartFile -> File로 변환이 실패하였습니다."),
 
 	_AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5000","AI 서버에서 문제가 발생했습니다."),
-	_AI_EXTRACT_DATA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5001","AI에서 썸네일과 추천 키워드을 가져오지 못했습니다.");
+	_AI_EXTRACT_DATA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5001","AI에서 썸네일과 추천 키워드을 가져오지 못했습니다."),
+
+	_S3_HTML_FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S35001", "S3에 저장된 html 파일을 삭제하는데 실패했습니다.");
 
 	private HttpStatus httpStatus;
 	private String code;


### PR DESCRIPTION
## 💡 개요
스타 생성 취소(완전 삭제) 기능 구현 + 삭제 안된 스타만 조회하는 기능으로 수정

## 🔨작업 사항
### 스타 생성 취소 기능
```
@Override
    public DeleteStarResponseDTO cancelStar(UUID starId){
        Star star = starRepository.findById(starId)
                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));

        s3Service.deleteHtmlFileInS3(star.getHtmlFileUrl());
        starRepository.delete(star);

        String canceledMessage = "Star with ID : " + starId + " was completely deleted";
        return DeleteStarResponseDTO.builder()
                .starId(starId)
                .deleteStatus(canceledMessage)
                .build();
    }
```
- 스타 생성 취소하는 경우는 크롬익스텐션에서 북마크 추가까지는 했지만 그 다음 과정에서 취소한 경우임
- 그래서 이미 스타 노드와 html 파일이 저장되어 있기 때문에 취소할 경우 둘 다 삭제함

### 스타 조회기능 수정
- Soft Delete로 인해 isDeletedStatus=false인 스타만 조회하는 쿼리로 수정함

### 기능별 Swagger 설명 추가
- 프론트와 API 연동을 더욱 편하게 하기 위해 설명을 추가함

## 📝 기타 (선택)
- 설계한 API는 다 구현함. 프론트와 연동하면서 계속 수정할듯