### PR TITLE
SCRUM 158 : 스타 정보 수정 기능 Refactor + 고립 키워드 노드 삭제 기능 구현

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/keyword/api/KeywordController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/api/KeywordController.java
@@ -1,0 +1,29 @@
+package com.team_nebula.nebula.domain.keyword.api;
+
+import com.team_nebula.nebula.domain.keyword.service.KeywordCommandService;
+import com.team_nebula.nebula.global.apipayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "[ 키워드 ]")
+@RequestMapping("/api/v1/keywords")
+public class KeywordController {
+
+    private final KeywordCommandService keywordCommandService;
+
+    // 고립된 키워드 노드 삭제 API
+    @Operation(summary = "고립 키워드 삭제", description = "키워드 노드는 공유 노드이기 때문에 고립된 노드가 발생가능. 그래서 관리자가 고립된 키워드 노드를 삭제할 수 있어야함")
+    @GetMapping("/cleanup")
+    public ApiResponse<String> cleanupKeywords() {
+        String deleteMessage = keywordCommandService.deleteKeywords();
+        return ApiResponse.onSuccess(deleteMessage);
+    }
+
+}

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -17,4 +17,21 @@ public interface KeywordRepository extends Neo4jRepository<Keyword, String> {
         MERGE (s)-[:TAGGED]->(k);
     """)
     void linkStarToKeywords(@Param("starId") UUID starId, @Param("keywordNames") List<String> keywordNames);
+
+    @Query("""
+    MATCH (s:Star {id: $starId})-[t:TAGGED]->(k:Keyword)
+    DELETE t
+    """)
+    void removeKeywordRelations(@Param("starId") UUID starId);
+
+    @Query("""
+    MATCH (k:Keyword)
+    WHERE NOT (k)<-[:TAGGED]-(:Star)
+    WITH COLLECT(k.name) AS orphanKeywordNames, k
+    DELETE k
+    RETURN orphanKeywordNames
+    """)
+    List<String> removeOrphanKeywords();
+
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandService.java
@@ -6,4 +6,8 @@ import java.util.List;
 
 public interface KeywordCommandService {
     public void linkStarToKeywords(Star star, List<String> keywordNames);
-}
+
+    public void updateKeywordsForStar(Star star, List<String> newKeywordNames);
+
+    public String deleteKeywords();
+    }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,4 +30,30 @@ public class KeywordCommandServiceImpl implements KeywordCommandService {
             throw new GeneralException(ErrorStatus._KEYWORD_NOT_FOUND);
         }
     }
+
+    @Override
+    public void updateKeywordsForStar(Star star, List<String> newKeywordNames) {
+        keywordRepository.removeKeywordRelations(star.getId());
+
+        if (newKeywordNames != null && !newKeywordNames.isEmpty()) {
+            keywordRepository.linkStarToKeywords(star.getId(), newKeywordNames);
+        }
+    }
+
+    public String deleteKeywords() {
+        List<String> orphanKeywords = keywordRepository.removeOrphanKeywords();
+        if (orphanKeywords.isEmpty()) {
+            throw new GeneralException(ErrorStatus._ORPHAN_KEYWORD_NOT_EXIST);
+        }
+        String deleteMessage = "Keywords deleted: " + orphanKeywords;
+        return deleteMessage;
+    }
+
+
+//    @Scheduled(cron = "0 0 3 * * ?")
+//    public void cleanUpOrphanKeywords() {
+//        log.info("고립된 키워드 정리 시작");
+//        keywordRepository.removeOrphanKeywords();
+//        log.info("고립된 키워드 정리 완료");
+//    }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/UpdateStarOneRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/UpdateStarOneRequestDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -14,4 +16,5 @@ public class UpdateStarOneRequestDTO {
     String categoryName;
     String summaryAI;
     String userMemo;
+    List<String> keywords;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -176,30 +177,16 @@ public class StarCommandServiceImpl implements StarCommandService {
         Star star = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
-        String categoryName = "";
+        Optional.ofNullable(requestDTO.getTitle()).ifPresent(star::updateTitle);
+        Optional.ofNullable(requestDTO.getSummaryAI()).ifPresent(star::updateSummaryAI);
+        Optional.ofNullable(requestDTO.getUserMemo()).ifPresent(star::updateUserMemo);
+        Optional.ofNullable(requestDTO.getKeywords()).ifPresent(keywords ->
+                keywordCommandService.updateKeywordsForStar(star, keywords));
 
-        if(requestDTO.getTitle() != null){
-            star.updateTitle(requestDTO.getTitle());
-        }
+        String categoryName = Optional.ofNullable(requestDTO.getCategoryName())
+                .map(category -> categoryCommandService.linkStarToCategoryAndGetName(star, category))
+                .orElseGet(() -> categoryQueryService.findCategoryNameByStar(star.getId()));
 
-        if(requestDTO.getCategoryName() != null){
-            categoryName = categoryCommandService.linkStarToCategoryAndGetName(star, requestDTO.getCategoryName());
-        }
-        else{
-            categoryName = categoryQueryService.findCategoryNameByStar(star.getId());
-        }
-
-        if(requestDTO.getSummaryAI() != null){
-            star.updateSummaryAI(requestDTO.getSummaryAI());
-        }
-
-        if(requestDTO.getUserMemo() != null){
-            star.updateUserMemo(requestDTO.getUserMemo());
-        }
-
-        if (requestDTO.getKeywords() != null) {
-            keywordCommandService.updateKeywordsForStar(star, requestDTO.getKeywords());
-        }
 
         Star updateStar = starRepository.save(star);
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -197,6 +197,10 @@ public class StarCommandServiceImpl implements StarCommandService {
             star.updateUserMemo(requestDTO.getUserMemo());
         }
 
+        if (requestDTO.getKeywords() != null) {
+            keywordCommandService.updateKeywordsForStar(star, requestDTO.getKeywords());
+        }
+
         Star updateStar = starRepository.save(star);
 
         return GetStarOneResponseDTO.builder()

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -26,6 +26,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	_KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD4001", "해당 스타안에 키워드를 찾지 못했습니다."),
 	_KEYWORD_NOT_INPUT(HttpStatus.NOT_ACCEPTABLE, "KEYWORD4002", "키워드가 입력되지 않았습니다."),
+	_ORPHAN_KEYWORD_NOT_EXIST(HttpStatus.NOT_FOUND, "KEYWORD4003", "고립된 키워드가 존재하지 않습니다."),
+
 
 	_MULTIPARTFILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,"MULTIPARTFILE5000","MultipartFile -> File로 변환이 실패하였습니다."),
 


### PR DESCRIPTION
## 💡 개요
스타 정보 수정시 스타안에 있는 키워드 수정 기능 추가 + 고립 키워드 노드 삭제 기능 구현

## 🔨작업 사항
### 스타 정보 수정시 스타안에 있는 키워드 수정 기능 추가
![image](https://github.com/user-attachments/assets/86451761-5edb-40f3-bddb-b9967d8069fa)
- 프론트의 요청으로 스타안에 키워드만 따로 수정하는게 아니라 스타 전체를 한번에 수정하기로 함


### 고림 키워드 노드 삭제 기능 구현
- 키워드 노드는 공유 노드이기 때문에 수정하거나 삭제해도 노드 자체를 삭제하는게 아니라 관계만 삭제됨
- 그래서 관계가 아예 없는 키워드 노드가 존재할 수 있기때문에 삭제 기능을 구현함
- 이 기능은 관리자 입장에서 사용할 예정
```
//    @Scheduled(cron = "0 0 3 * * ?")
//    public void cleanUpOrphanKeywords() {
//        log.info("고립된 키워드 정리 시작");
//        keywordRepository.removeOrphanKeywords();
//        log.info("고립된 키워드 정리 완료");
//    }
```
- 스케줄러를 이용하는 방식도 사용 가능한데 아직 데이터가 맍지 않으므로 나중에 써도 괜찮을 듯함
