### PR TITLE
SCRUM-172: 이용약관 API 구현

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/term/api/TermController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/api/TermController.java
@@ -1,14 +1,18 @@
 package com.team_nebula.nebula.domain.term.api;
 
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
+import com.team_nebula.nebula.domain.term.dto.response.TermResponseDTO;
 import com.team_nebula.nebula.domain.term.entity.Term;
 import com.team_nebula.nebula.domain.term.service.TermService;
-import com.team_nebula.nebula.global.annotation.AuthUser;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,8 +27,13 @@ public class TermController {
 	private final TermService termService;
 
 	@PostMapping
-	public ApiResponse<?> createTerm(@AuthUser Long userId, @RequestBody TermRequestDTO request) {
-		Term term = termService.createTerm(userId, request);
+	public ApiResponse<?> createTerm(@RequestBody TermRequestDTO request) {
+		Term term = termService.createTerm(request);
 		return ApiResponse.onSuccessCreated("termId: " + term.getId());
+	}
+
+	@GetMapping
+	public ApiResponse<List<TermResponseDTO>> getTerms() {
+		return ApiResponse.onSuccess(termService.getTerms());
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/api/TermController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/api/TermController.java
@@ -2,11 +2,12 @@ package com.team_nebula.nebula.domain.term.api;
 
 import java.util.List;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
@@ -35,5 +36,11 @@ public class TermController {
 	@GetMapping
 	public ApiResponse<List<TermResponseDTO>> getTerms() {
 		return ApiResponse.onSuccess(termService.getTerms());
+	}
+
+	@DeleteMapping("/{termId}")
+	public ApiResponse<?> deleteTerm(@PathVariable Long termId) {
+		termService.deleteTerm(termId);
+		return ApiResponse.onSuccess("이용약관 삭제 성공");
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/api/TermController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/api/TermController.java
@@ -10,10 +10,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.team_nebula.nebula.domain.term.dto.request.AgreeTermRequestDTO;
 import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
 import com.team_nebula.nebula.domain.term.dto.response.TermResponseDTO;
 import com.team_nebula.nebula.domain.term.entity.Term;
 import com.team_nebula.nebula.domain.term.service.TermService;
+import com.team_nebula.nebula.global.annotation.AuthUser;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,5 +44,12 @@ public class TermController {
 	public ApiResponse<?> deleteTerm(@PathVariable Long termId) {
 		termService.deleteTerm(termId);
 		return ApiResponse.onSuccess("이용약관 삭제 성공");
+	}
+
+	@PostMapping("/agree")
+	public ApiResponse<?> agreeTerm(@AuthUser Long userId,
+		@RequestBody AgreeTermRequestDTO request) {
+		termService.agreeTerm(userId, request);
+		return ApiResponse.onSuccess("이용약관 동의 성공");
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/api/TermController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/api/TermController.java
@@ -1,0 +1,30 @@
+package com.team_nebula.nebula.domain.term.api;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
+import com.team_nebula.nebula.domain.term.entity.Term;
+import com.team_nebula.nebula.domain.term.service.TermService;
+import com.team_nebula.nebula.global.annotation.AuthUser;
+import com.team_nebula.nebula.global.apipayload.ApiResponse;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "[ 이용약관 ]")
+@RequestMapping("/api/v1/terms")
+public class TermController {
+
+	private final TermService termService;
+
+	@PostMapping
+	public ApiResponse<?> createTerm(@AuthUser Long userId, @RequestBody TermRequestDTO request) {
+		Term term = termService.createTerm(userId, request);
+		return ApiResponse.onSuccessCreated("termId: " + term.getId());
+	}
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/converter/TermConverter.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/converter/TermConverter.java
@@ -1,15 +1,25 @@
 package com.team_nebula.nebula.domain.term.converter;
 
 import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
+import com.team_nebula.nebula.domain.term.dto.response.TermResponseDTO;
 import com.team_nebula.nebula.domain.term.entity.Term;
 
 public class TermConverter {
 
-	public static Term of(Long userId, TermRequestDTO request) {
+	public static Term of(TermRequestDTO request) {
 		return Term.builder()
 			.name(request.getName())
 			.content(request.getContent())
 			.termType(request.getType())
+			.build();
+	}
+
+	public static TermResponseDTO toTermResponseDTO(Term term) {
+		return TermResponseDTO.builder()
+			.id(term.getId())
+			.name(term.getName())
+			.content(term.getContent())
+			.type(term.getTermType())
 			.build();
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/converter/TermConverter.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/converter/TermConverter.java
@@ -1,0 +1,15 @@
+package com.team_nebula.nebula.domain.term.converter;
+
+import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
+import com.team_nebula.nebula.domain.term.entity.Term;
+
+public class TermConverter {
+
+	public static Term of(Long userId, TermRequestDTO request) {
+		return Term.builder()
+			.name(request.getName())
+			.content(request.getContent())
+			.termType(request.getType())
+			.build();
+	}
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/dto/request/AgreeTermRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/dto/request/AgreeTermRequestDTO.java
@@ -1,0 +1,10 @@
+package com.team_nebula.nebula.domain.term.dto.request;
+
+import java.util.Map;
+
+import lombok.Getter;
+
+@Getter
+public class AgreeTermRequestDTO {
+	Map<Integer, Boolean> agreeMap;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/dto/request/TermRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/dto/request/TermRequestDTO.java
@@ -1,0 +1,12 @@
+package com.team_nebula.nebula.domain.term.dto.request;
+
+import com.team_nebula.nebula.domain.term.entity.TermType;
+
+import lombok.Getter;
+
+@Getter
+public class TermRequestDTO {
+	private String name;
+	private String content;
+	private TermType type;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/dto/response/TermResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/dto/response/TermResponseDTO.java
@@ -1,0 +1,15 @@
+package com.team_nebula.nebula.domain.term.dto.response;
+
+import com.team_nebula.nebula.domain.term.entity.TermType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TermResponseDTO {
+	private Long id;
+	private String name;
+	private String content;
+	private TermType type;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/entity/Term.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/entity/Term.java
@@ -4,6 +4,8 @@ import com.team_nebula.nebula.global.common.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,12 +31,12 @@ public class Term extends BaseEntity {
 	@Column(name = "content", nullable = false)
 	private String content;
 
-	@Column(name = "termType", nullable = false)
+	@Column(name = "term_type", nullable = false)
+	@Enumerated(EnumType.STRING)
 	private TermType termType;
 
 	@Builder
-	public Term(Long id, String name, String content, TermType termType) {
-		this.id = id;
+	public Term(String name, String content, TermType termType) {
 		this.name = name;
 		this.content = content;
 		this.termType = termType;

--- a/src/main/java/com/team_nebula/nebula/domain/term/entity/Term.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/entity/Term.java
@@ -1,0 +1,42 @@
+package com.team_nebula.nebula.domain.term.entity;
+
+import com.team_nebula.nebula.global.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "terms")
+public class Term extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	@Column(name = "termType", nullable = false)
+	private TermType termType;
+
+	@Builder
+	public Term(Long id, String name, String content, TermType termType) {
+		this.id = id;
+		this.name = name;
+		this.content = content;
+		this.termType = termType;
+	}
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/entity/TermType.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/entity/TermType.java
@@ -1,0 +1,5 @@
+package com.team_nebula.nebula.domain.term.entity;
+
+public enum TermType {
+	MANDATORY,OPTIONAL
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/entity/UserTerm.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/entity/UserTerm.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,4 +35,11 @@ public class UserTerm extends BaseEntity {
 
 	@Column(name = "agreed", nullable = false)
 	private boolean agreed;
+
+	@Builder
+	public UserTerm(User user, Term term, boolean agreed) {
+		this.user = user;
+		this.term = term;
+		this.agreed = agreed;
+	}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/entity/UserTerm.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/entity/UserTerm.java
@@ -1,0 +1,37 @@
+package com.team_nebula.nebula.domain.term.entity;
+
+import com.team_nebula.nebula.domain.user.entity.User;
+import com.team_nebula.nebula.global.common.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_terms")
+@IdClass(UserTermId.class)
+public class UserTerm extends BaseEntity {
+
+	@Id
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Id
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "term_id", nullable = false)
+	private Term term;
+
+	@Column(name = "agreed", nullable = false)
+	private boolean agreed;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/entity/UserTermId.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/entity/UserTermId.java
@@ -1,0 +1,17 @@
+package com.team_nebula.nebula.domain.term.entity;
+
+import java.io.Serializable;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class UserTermId implements Serializable {
+	private Long user;
+	private Long term;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/repository/TermRepository.java
@@ -1,10 +1,14 @@
 package com.team_nebula.nebula.domain.term.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.team_nebula.nebula.domain.term.entity.Term;
+import com.team_nebula.nebula.domain.term.entity.TermType;
 
 @Repository
 public interface TermRepository extends JpaRepository<Term, Long> {
+	List<Term> findByTermType(TermType termType);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/repository/TermRepository.java
@@ -1,0 +1,10 @@
+package com.team_nebula.nebula.domain.term.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.team_nebula.nebula.domain.term.entity.Term;
+
+@Repository
+public interface TermRepository extends JpaRepository<Term, Long> {
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/repository/UserTermRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/repository/UserTermRepository.java
@@ -1,0 +1,10 @@
+package com.team_nebula.nebula.domain.term.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.team_nebula.nebula.domain.term.entity.UserTerm;
+
+@Repository
+public interface UserTermRepository extends JpaRepository<UserTerm, Long> {
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/repository/UserTermRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/repository/UserTermRepository.java
@@ -1,10 +1,15 @@
 package com.team_nebula.nebula.domain.term.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.team_nebula.nebula.domain.term.entity.UserTerm;
+import com.team_nebula.nebula.domain.user.entity.User;
 
 @Repository
 public interface UserTermRepository extends JpaRepository<UserTerm, Long> {
+	List<UserTerm> findByUser(User user);
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/service/TermService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/service/TermService.java
@@ -2,6 +2,7 @@ package com.team_nebula.nebula.domain.term.service;
 
 import java.util.List;
 
+import com.team_nebula.nebula.domain.term.dto.request.AgreeTermRequestDTO;
 import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
 import com.team_nebula.nebula.domain.term.dto.response.TermResponseDTO;
 import com.team_nebula.nebula.domain.term.entity.Term;
@@ -13,4 +14,6 @@ public interface TermService {
 	List<TermResponseDTO> getTerms();
 
 	void deleteTerm(Long termId);
+
+	void agreeTerm(Long userId, AgreeTermRequestDTO request);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/service/TermService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/service/TermService.java
@@ -1,0 +1,9 @@
+package com.team_nebula.nebula.domain.term.service;
+
+import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
+import com.team_nebula.nebula.domain.term.entity.Term;
+
+public interface TermService {
+
+	Term createTerm(Long userId, TermRequestDTO request);
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/service/TermService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/service/TermService.java
@@ -1,9 +1,14 @@
 package com.team_nebula.nebula.domain.term.service;
 
+import java.util.List;
+
 import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
+import com.team_nebula.nebula.domain.term.dto.response.TermResponseDTO;
 import com.team_nebula.nebula.domain.term.entity.Term;
 
 public interface TermService {
 
-	Term createTerm(Long userId, TermRequestDTO request);
+	Term createTerm(TermRequestDTO request);
+
+	List<TermResponseDTO> getTerms();
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/service/TermService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/service/TermService.java
@@ -11,4 +11,6 @@ public interface TermService {
 	Term createTerm(TermRequestDTO request);
 
 	List<TermResponseDTO> getTerms();
+
+	void deleteTerm(Long termId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/service/TermServiceImpl.java
@@ -1,0 +1,20 @@
+package com.team_nebula.nebula.domain.term.service;
+
+import org.springframework.stereotype.Service;
+
+import com.team_nebula.nebula.domain.term.converter.TermConverter;
+import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
+import com.team_nebula.nebula.domain.term.entity.Term;
+
+import jakarta.transaction.Transactional;
+
+@Service
+public class TermServiceImpl implements TermService {
+
+	@Override
+	@Transactional
+	public Term createTerm(Long userId, TermRequestDTO request) {
+
+		return TermConverter.of(userId, request);
+	}
+}

--- a/src/main/java/com/team_nebula/nebula/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/service/TermServiceImpl.java
@@ -6,10 +6,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.team_nebula.nebula.domain.term.converter.TermConverter;
+import com.team_nebula.nebula.domain.term.dto.request.AgreeTermRequestDTO;
 import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
 import com.team_nebula.nebula.domain.term.dto.response.TermResponseDTO;
 import com.team_nebula.nebula.domain.term.entity.Term;
+import com.team_nebula.nebula.domain.term.entity.TermType;
+import com.team_nebula.nebula.domain.term.entity.UserTerm;
 import com.team_nebula.nebula.domain.term.repository.TermRepository;
+import com.team_nebula.nebula.domain.term.repository.UserTermRepository;
+import com.team_nebula.nebula.domain.user.entity.User;
+import com.team_nebula.nebula.domain.user.repository.mysql.UserRepository;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 
@@ -20,6 +26,8 @@ import lombok.RequiredArgsConstructor;
 public class TermServiceImpl implements TermService {
 
 	private final TermRepository termRepository;
+	private final UserTermRepository userTermRepository;
+	private final UserRepository userRepository;
 
 	@Override
 	@Transactional
@@ -50,5 +58,34 @@ public class TermServiceImpl implements TermService {
 			.orElseThrow(() -> new GeneralException(ErrorStatus._TERM_NOT_FOUND));
 
 		termRepository.delete(term);
+	}
+
+	@Override
+	@Transactional
+	public void agreeTerm(Long userId, AgreeTermRequestDTO request) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+		for (Integer key : request.getAgreeMap().keySet()) {
+
+			Long termId = key.longValue();
+			Boolean agreed = request.getAgreeMap().get(key);
+
+			Term term = termRepository.findById(termId)
+				.orElseThrow(() -> new GeneralException(ErrorStatus._TERM_NOT_FOUND));
+
+			if (term.getTermType().equals(TermType.MANDATORY) && !Boolean.TRUE.equals(agreed)) {
+				throw new GeneralException(ErrorStatus._REQUIRED_TERM_NOT_AGREED);
+			}
+
+			UserTerm userTerm = UserTerm.builder()
+				.user(user)
+				.term(term)
+				.agreed(request.getAgreeMap().get(key))
+				.build();
+
+			userTermRepository.save(userTerm);
+		}
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/service/TermServiceImpl.java
@@ -1,6 +1,7 @@
 package com.team_nebula.nebula.domain.term.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,22 +68,30 @@ public class TermServiceImpl implements TermService {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-		for (Integer key : request.getAgreeMap().keySet()) {
+		List<Term> mandatoryTerms = termRepository.findByTermType(TermType.MANDATORY);
 
-			Long termId = key.longValue();
-			Boolean agreed = request.getAgreeMap().get(key);
+		for (Term mandatoryTerm : mandatoryTerms) {
+
+			Boolean agreed = request.getAgreeMap().get(mandatoryTerm.getId().intValue());
+
+			if (agreed == null || !agreed) {
+
+				throw new GeneralException(ErrorStatus._TERM_NOT_AGREED);
+			}
+		}
+
+		for (Map.Entry<Integer, Boolean> entry : request.getAgreeMap().entrySet()) {
+
+			Long termId = entry.getKey().longValue();
+			Boolean agreed = entry.getValue();
 
 			Term term = termRepository.findById(termId)
 				.orElseThrow(() -> new GeneralException(ErrorStatus._TERM_NOT_FOUND));
 
-			if (term.getTermType().equals(TermType.MANDATORY) && !Boolean.TRUE.equals(agreed)) {
-				throw new GeneralException(ErrorStatus._REQUIRED_TERM_NOT_AGREED);
-			}
-
 			UserTerm userTerm = UserTerm.builder()
 				.user(user)
 				.term(term)
-				.agreed(request.getAgreeMap().get(key))
+				.agreed(agreed)
 				.build();
 
 			userTermRepository.save(userTerm);

--- a/src/main/java/com/team_nebula/nebula/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/service/TermServiceImpl.java
@@ -1,20 +1,38 @@
 package com.team_nebula.nebula.domain.term.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.team_nebula.nebula.domain.term.converter.TermConverter;
 import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
+import com.team_nebula.nebula.domain.term.dto.response.TermResponseDTO;
 import com.team_nebula.nebula.domain.term.entity.Term;
+import com.team_nebula.nebula.domain.term.repository.TermRepository;
 
-import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
 public class TermServiceImpl implements TermService {
+
+	private final TermRepository termRepository;
 
 	@Override
 	@Transactional
-	public Term createTerm(Long userId, TermRequestDTO request) {
+	public Term createTerm(TermRequestDTO request) {
 
-		return TermConverter.of(userId, request);
+		return TermConverter.of(request);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<TermResponseDTO> getTerms() {
+		List<Term> terms = termRepository.findAll();
+
+		return terms.stream()
+			.map(TermConverter::toTermResponseDTO)
+			.toList();
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/term/service/TermServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/term/service/TermServiceImpl.java
@@ -10,6 +10,8 @@ import com.team_nebula.nebula.domain.term.dto.request.TermRequestDTO;
 import com.team_nebula.nebula.domain.term.dto.response.TermResponseDTO;
 import com.team_nebula.nebula.domain.term.entity.Term;
 import com.team_nebula.nebula.domain.term.repository.TermRepository;
+import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
+import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,7 +25,11 @@ public class TermServiceImpl implements TermService {
 	@Transactional
 	public Term createTerm(TermRequestDTO request) {
 
-		return TermConverter.of(request);
+		Term term = TermConverter.of(request);
+
+		termRepository.save(term);
+
+		return term;
 	}
 
 	@Override
@@ -34,5 +40,15 @@ public class TermServiceImpl implements TermService {
 		return terms.stream()
 			.map(TermConverter::toTermResponseDTO)
 			.toList();
+	}
+
+	@Override
+	@Transactional
+	public void deleteTerm(Long termId) {
+
+		Term term = termRepository.findById(termId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._TERM_NOT_FOUND));
+
+		termRepository.delete(term);
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -38,7 +38,9 @@ public enum ErrorStatus implements BaseErrorCode {
 	_S3_HTML_FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S35001", "S3에 저장된 html 파일을 삭제하는데 실패했습니다."),
 
 	_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN4001", "토큰이 만료되었습니다."),
-	_TOKEN_TYPE_ERROR(HttpStatus.BAD_REQUEST, "TOKEN4002", "토큰 타입이 잘못되었습니다.");
+	_TOKEN_TYPE_ERROR(HttpStatus.BAD_REQUEST, "TOKEN4002", "토큰 타입이 잘못되었습니다."),
+
+	_TERM_NOT_FOUND(HttpStatus.BAD_REQUEST, "TERM4001", "이용약관을 찾을 수 없습니다.");
 
 
 	private HttpStatus httpStatus;

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -40,7 +40,8 @@ public enum ErrorStatus implements BaseErrorCode {
 	_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN4001", "토큰이 만료되었습니다."),
 	_TOKEN_TYPE_ERROR(HttpStatus.BAD_REQUEST, "TOKEN4002", "토큰 타입이 잘못되었습니다."),
 
-	_TERM_NOT_FOUND(HttpStatus.BAD_REQUEST, "TERM4001", "이용약관을 찾을 수 없습니다.");
+	_TERM_NOT_FOUND(HttpStatus.BAD_REQUEST, "TERM4001", "이용약관을 찾을 수 없습니다."),
+	_REQUIRED_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST, "TERM4002", "필수 동의 약관 입니다.");
 
 
 	private HttpStatus httpStatus;

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -41,7 +41,9 @@ public enum ErrorStatus implements BaseErrorCode {
 	_TOKEN_TYPE_ERROR(HttpStatus.BAD_REQUEST, "TOKEN4002", "토큰 타입이 잘못되었습니다."),
 
 	_TERM_NOT_FOUND(HttpStatus.BAD_REQUEST, "TERM4001", "이용약관을 찾을 수 없습니다."),
-	_REQUIRED_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST, "TERM4002", "필수 동의 약관 입니다.");
+	_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST, "TERM4002", "필수 동의 약관 입니다."),
+
+	_USER_TERM_NOT_FOUND(HttpStatus.BAD_REQUEST, "USERTERM4001", "유저 이용약관을 찾을 수 없습니다.");
 
 
 	private HttpStatus httpStatus;

--- a/src/main/java/com/team_nebula/nebula/global/config/MySQLConfig.java
+++ b/src/main/java/com/team_nebula/nebula/global/config/MySQLConfig.java
@@ -1,5 +1,8 @@
 package com.team_nebula.nebula.global.config;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import jakarta.persistence.EntityManagerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -17,7 +20,10 @@ import javax.sql.DataSource;
 
 @Configuration
 @EnableJpaRepositories(
-        basePackages = "com.team_nebula.nebula.domain.user.repository.mysql", // MySQL 관련 Repository 위치
+        basePackages = {
+            "com.team_nebula.nebula.domain.user.repository.mysql",
+            "com.team_nebula.nebula.domain.term.repository"
+        }, // MySQL 관련 Repository 위치
         entityManagerFactoryRef = "mysqlEntityManager",
         transactionManagerRef = "mysqlTransactionManager"
 )
@@ -35,10 +41,18 @@ public class MySQLConfig {
     public LocalContainerEntityManagerFactoryBean mysqlEntityManager(
             EntityManagerFactoryBuilder builder,
             @Qualifier("mysqlDataSource") DataSource dataSource) {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("hibernate.hbm2ddl.auto", "update");
+
         return builder
                 .dataSource(dataSource)
-                .packages("com.team_nebula.nebula.domain") // MySQL Entity 경로
+                .packages(
+                    "com.team_nebula.nebula.domain.user.entity",
+                    "com.team_nebula.nebula.domain.term.entity"
+                )
                 .persistenceUnit("mysql")
+                .properties(properties)
                 .build();
     }
 

--- a/src/main/java/com/team_nebula/nebula/global/config/SecurityConfig.java
+++ b/src/main/java/com/team_nebula/nebula/global/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
 					configuration.setAllowCredentials(true);
 					configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
 					configuration.setAllowedHeaders(Collections.singletonList("*"));
-					configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+					configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
 					configuration.setExposedHeaders(Arrays.asList("Set-Cookie", "Authorization"));
 					configuration.setMaxAge(3600L);
 

--- a/src/main/java/com/team_nebula/nebula/global/oauth/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/team_nebula/nebula/global/oauth/handler/CustomSuccessHandler.java
@@ -3,6 +3,7 @@ package com.team_nebula.nebula.global.oauth.handler;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -10,6 +11,8 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
+import com.team_nebula.nebula.domain.term.entity.UserTerm;
+import com.team_nebula.nebula.domain.term.repository.UserTermRepository;
 import com.team_nebula.nebula.domain.user.entity.User;
 import com.team_nebula.nebula.domain.user.repository.mysql.UserRepository;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
@@ -23,9 +26,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
@@ -36,10 +37,12 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	private String extensionRedirectUrl;
 
 	private final UserRepository userRepository;
+	private final UserTermRepository userTermRepository;
 	private final JWTUtil jwtUtil;
 
-	public CustomSuccessHandler(UserRepository userRepository, JWTUtil jwtUtil) {
+	public CustomSuccessHandler(UserRepository userRepository, UserTermRepository userTermRepository, JWTUtil jwtUtil) {
 		this.userRepository = userRepository;
+		this.userTermRepository = userTermRepository;
 		this.jwtUtil = jwtUtil;
 	}
 
@@ -77,6 +80,12 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 		redirectUrl = String.format("%s?accessToken=%s&refreshToken=%s", redirectUrl,
 			tokenResponseDTO.getAccessToken(), tokenResponseDTO.getRefreshToken());
+
+		List<UserTerm> userTerms = userTermRepository.findByUser(user);
+
+		boolean isAgreed = !userTerms.isEmpty();
+
+		redirectUrl = String.format("%s&isAgreed=%s", redirectUrl, isAgreed);
 
 		response.sendRedirect(redirectUrl);
 


### PR DESCRIPTION
## 💡 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🔨작업 사항
<!---- 어떤 변경 사항이 있나요?-->
<img width="215" alt="image" src="https://github.com/user-attachments/assets/c934e0d5-1e79-4ae7-b77a-69b449959df8" />

## Term(이용약관) 도메인 생성

<img width="463" alt="image" src="https://github.com/user-attachments/assets/ba7f2505-6014-42bb-b01c-d7a8164898c6" />


- 이용약관에 대한 이름, 내용, 타입(필수, 선택) 을 지정하여 데이터 생성

## UserTerm 도메인 생성
<img width="448" alt="image" src="https://github.com/user-attachments/assets/8f08ab34-ea76-4ef4-bdbb-7a2c7f6953c6" />

- Term과 User 사이 중간 테이블인 UserTerm 테이블로 해당 유저의 이용약관 동의 데이터 관리

</br>

<img width="413" alt="image" src="https://github.com/user-attachments/assets/bf7e2037-d48b-447d-8ee7-75406359a851" />

- UserTermId 클래스를 두어 userId와 termId를 복합키 PK로 설정

</br>

# API

</.br>

## 이용약관 생성 API

```
{
  "name": "string",
  "content": "string",
  "type": "MANDATORY"
}
```

이용약관 제목, 내용, 타입(필수, 선택) 을 지정하여 데이터 생성

</br>

## 이용약관 전체 조회 API
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/752d4341-89db-48ec-aad9-301bc06d322c" />

</br>

## 이용약관 삭제 API
<img width="1441" alt="image" src="https://github.com/user-attachments/assets/6da3d265-435c-4dac-aa51-9ca84f00c37d" />

</br>

## 이용약관 동의 API
<img width="1426" alt="image" src="https://github.com/user-attachments/assets/3dfda142-fe72-4abf-8035-2ea7c846f027" />

Map으로 이용약관id와 동의 여부를 전달

- 필수 약관을 동의 안하면 `필수 약관 동의입니다.` 에러 핸들링

</br>

# 소셜 로그인 시 동의 여부
<img width="119" alt="image" src="https://github.com/user-attachments/assets/6234f397-dbe3-4955-b4e9-f00bcd2ed2b1" />

</br>

소셜 로그인 성공 후 이용약관 데이터 여부를 통해 동의 여부를 파라미터로 응답

## 📝 기타 (선택)
<!---- 참고 사항이나 리뷰어에게 전달하고 싶은 내용이 있나요?-->
