### PR TITLE
SCRUM -169 : 유저 스타 작업 체크 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -1,6 +1,7 @@
 package com.team_nebula.nebula.domain.keyword.repository;
 
 import com.team_nebula.nebula.domain.keyword.entity.Keyword;
+import com.team_nebula.nebula.domain.star.entity.Star;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.query.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,10 +20,16 @@ public interface KeywordRepository extends Neo4jRepository<Keyword, String> {
     void linkStarToKeywords(@Param("starId") UUID starId, @Param("keywordNames") List<String> keywordNames);
 
     @Query("""
-        MATCH (s:Star {id: $starId})-[t:TAGGED]->(k:Keyword)
+        MATCH (s:Star {id: $starId})-[t:TAGGED]->(:Keyword)
         DELETE t
+    
+        WITH s
+        UNWIND apoc.coll.toSet($keywordNames) AS keywordName
+        MERGE (k:Keyword {name: keywordName})
+        MERGE (s)-[:TAGGED]->(k)
+        RETURN s;
     """)
-    void removeKeywordRelations(@Param("starId") UUID starId);
+    Star removeLinkAndReconnect(@Param("starId") UUID starId, @Param("keywordNames") List<String> keywordNames);
 
     @Query("""
         MATCH (k:Keyword)

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
@@ -1,9 +1,12 @@
 package com.team_nebula.nebula.domain.keyword.service;
 
 import com.team_nebula.nebula.domain.keyword.repository.KeywordRepository;
+import com.team_nebula.nebula.domain.link.repository.LinkRepository;
 import com.team_nebula.nebula.domain.star.entity.Star;
+import com.team_nebula.nebula.domain.star.repository.StarRepository;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -17,6 +20,8 @@ import java.util.List;
 public class KeywordCommandServiceImpl implements KeywordCommandService {
 
     private final KeywordRepository keywordRepository;
+    private final LinkRepository linkrepository;
+    private final StarRepository starrepository;
 
     @Override
     public void linkStarToKeywords(Star star, List<String> keywordNames) {
@@ -33,20 +38,22 @@ public class KeywordCommandServiceImpl implements KeywordCommandService {
 
     @Override
     public void updateKeywordsForStar(Star star, List<String> newKeywordNames) {
-        keywordRepository.removeKeywordRelations(star.getId());
+        System.out.println("------변경 전 스타 - 키워드1 --------:"+ star.getKeywords());
+        // 키워드와 스타 연결 업데이트
+        Star updateStar = keywordRepository.removeLinkAndReconnect(star.getId(), newKeywordNames);
 
-        if (newKeywordNames != null && !newKeywordNames.isEmpty()) {
-            keywordRepository.linkStarToKeywords(star.getId(), newKeywordNames);
-        }
+        System.out.println("------변경된 스타 - 키워드1 --------:"+ updateStar.getKeywords());
+
+        linkrepository.updateLinksBetweenStars(updateStar.getId());
     }
 
+    @Override
     public String deleteKeywords() {
         List<String> orphanKeywords = keywordRepository.removeOrphanKeywords();
         if (orphanKeywords.isEmpty()) {
             throw new GeneralException(ErrorStatus._ORPHAN_KEYWORD_NOT_EXIST);
         }
-        String deleteMessage = "Keywords deleted: " + orphanKeywords;
-        return deleteMessage;
+        return "Keywords deleted: " + orphanKeywords;
     }
 
 

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
@@ -38,12 +38,9 @@ public class KeywordCommandServiceImpl implements KeywordCommandService {
 
     @Override
     public void updateKeywordsForStar(Star star, List<String> newKeywordNames) {
-        System.out.println("------변경 전 스타 - 키워드1 --------:"+ star.getKeywords());
         // 키워드와 스타 연결 업데이트
         Star updateStar = keywordRepository.removeLinkAndReconnect(star.getId(), newKeywordNames);
-
-        System.out.println("------변경된 스타 - 키워드1 --------:"+ updateStar.getKeywords());
-
+        // 링크 재설정
         linkrepository.updateLinksBetweenStars(updateStar.getId());
     }
 

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordQueryService.java
@@ -1,6 +1,5 @@
 package com.team_nebula.nebula.domain.keyword.service;
 
-import com.team_nebula.nebula.domain.user.entity.User;
 
 import java.util.List;
 

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/keywordQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/keywordQueryServiceImpl.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class keywordQueryServiceImpl implements  KeywordQueryService {
 
     private final KeywordRepository keywordRepository;

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -70,4 +70,28 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
            l.similarityScore AS similarity
     """)
     List<GetLinkOneResponseDTO> findLinkInKeyword(@Param("userId") Long userId, @Param("keywordId") String keywordId);
+
+    @Query("""
+    MATCH (s1:Star)-[r1:LINKED]->(l:Link)<-[r2:LINKED]-(s2)
+    WHERE s1.id = $starId
+    DELETE r1, r2
+    WITH s1,l
+    WHERE l IS NOT NULL
+    DETACH DELETE l
+    
+    WITH s1
+    MATCH (s1)-[:TAGGED]->(k:Keyword)<-[:TAGGED]-(s2:Star)
+    WHERE s1 <> s2
+    AND (s1.isDeletedStatus = false OR s1.isDeletedStatus IS NULL)
+    AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
+    
+    WITH s1, s2, COUNT(k) AS sharedKeywordNum
+    WHERE sharedKeywordNum > 0
+    MERGE (l:Link {linked_two_node_Id: [s1.id, s2.id]})
+    ON CREATE SET l.sharedKeywordNum = sharedKeywordNum, l.similarityScore = 0.5, l.id = randomUUID()
+    MERGE (s1)-[:LINKED]->(l)
+    MERGE (s2)-[:LINKED]->(l)
+    """)
+    void updateLinksBetweenStars(@Param("starId") UUID starId);
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -127,7 +127,7 @@ public class StarController {
     @Operation(summary = "스타 삭제", description = "스타를 비활성화하는 API/ 완전 삭제가 아닌 Soft Delete하는 것")
     @PatchMapping("/{starId}/deactivate")
     public ApiResponse<DeleteStarResponseDTO> deleteStar(@AuthUser Long userId, @PathVariable UUID starId){
-        DeleteStarResponseDTO responseDTO = starCommandService.deleteStar(starId);
+        DeleteStarResponseDTO responseDTO = starCommandService.deleteStar(userId, starId);
 
         return ApiResponse.onSuccess(responseDTO);
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -114,10 +114,11 @@ public class StarController {
     @Operation(summary = "스타 정보 수정", description = "특정 스타 정보를 수정하는 API / title(제목), categoryName(카테고리), summaryAI(AI요약), userMemo(사용자메모)를 각각 수정할 수 있음")
     @PatchMapping("/{starId}")
     public ApiResponse<GetStarOneResponseDTO> createCompleteStar(
+            @AuthUser Long userId,
             @PathVariable UUID starId,
             @RequestBody UpdateStarOneRequestDTO requestDTO
     ){
-        GetStarOneResponseDTO responseDTO = starCommandService.updateStar(starId, requestDTO);
+        GetStarOneResponseDTO responseDTO = starCommandService.updateStar(userId, starId, requestDTO);
 
         return ApiResponse.onSuccess(responseDTO);
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -18,7 +18,7 @@ public interface StarCommandService {
 
     public GetStarOneResponseDTO updateStar(Long userId, UUID starId, UpdateStarOneRequestDTO requestDTO);
 
-    public DeleteStarResponseDTO deleteStar(UUID starId);
+    public DeleteStarResponseDTO deleteStar(Long userId, UUID starId);
 
     public DeleteStarResponseDTO cancelStar(UUID starId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -16,7 +16,7 @@ public interface StarCommandService {
 
     public PutStarResponseDTO createCompleteStar(UUID starId, CreateStarRequestDTO requestDTO);
 
-    public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO);
+    public GetStarOneResponseDTO updateStar(Long userId, UUID starId, UpdateStarOneRequestDTO requestDTO);
 
     public DeleteStarResponseDTO deleteStar(UUID starId);
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -14,8 +14,6 @@ public interface StarCommandService {
 
     public CreateStarResponseDTO createFirstStar(Long userId, MultipartFile htmlFile, String title, String siteUrl);
 
-//    public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO);
-
     public PutStarResponseDTO createCompleteStar(UUID starId, CreateStarRequestDTO requestDTO);
 
     public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO);

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -6,7 +6,6 @@ import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.DeleteStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.PutStarResponseDTO;
-import com.team_nebula.nebula.domain.user.entity.User;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -71,7 +71,7 @@ public class StarCommandServiceImpl implements StarCommandService {
             userNodeRepository.save(userNode);
 
             // 유저 스타 수정 횟수 증가
-            aiService.checkUpdatedNum(userNode);
+            aiService.checkUpdatedCnt(userId);
 
             return CreateStarResponseDTO.builder()
                     .starId(savedStar.getId())
@@ -121,7 +121,7 @@ public class StarCommandServiceImpl implements StarCommandService {
 
 
     @Override
-    public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO){
+    public GetStarOneResponseDTO updateStar(Long userId, UUID starId, UpdateStarOneRequestDTO requestDTO){
         Star star = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
@@ -135,8 +135,10 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .map(category -> categoryCommandService.linkStarToCategoryAndGetName(star, category))
                 .orElseGet(() -> categoryQueryService.findCategoryNameByStar(star.getId()));
 
-
         Star updateStar = starRepository.save(star);
+
+        // 유저 스타 작업 횟수 증가
+        aiService.checkUpdatedCnt(userId);
 
         return GetStarOneResponseDTO.builder()
                 .starId(updateStar.getId())
@@ -154,12 +156,15 @@ public class StarCommandServiceImpl implements StarCommandService {
     }
 
     @Override
-    public DeleteStarResponseDTO deleteStar(UUID starId){
+    public DeleteStarResponseDTO deleteStar(Long userId, UUID starId){
         Star star = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
         star.updateIsDeletedStatus();
         starRepository.save(star);
+
+        // 유저 스타 작업 횟수 증가
+        aiService.checkUpdatedCnt(userId);
 
         String deleteMessage = "Star with ID : " + starId + " was deleted";
         return DeleteStarResponseDTO.builder()

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -108,6 +108,7 @@ public class StarCommandServiceImpl implements StarCommandService {
         linkCommandService.createLinksForStar(savedStar);
 
         savedStar.updateStar(requestDTO.getThumbnailUrl(), requestDTO.getSummaryAI(), requestDTO.getUserMemo());
+        starRepository.save(savedStar);
 
         return PutStarResponseDTO.builder()
                 .starId(star.getId())
@@ -135,7 +136,8 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .map(category -> categoryCommandService.linkStarToCategoryAndGetName(star, category))
                 .orElseGet(() -> categoryQueryService.findCategoryNameByStar(star.getId()));
 
-        Star updateStar = starRepository.save(star);
+        Star updateStar = starRepository.findById(starId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
         // 유저 스타 작업 횟수 증가
         aiService.checkUpdatedCnt(userId);

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -46,10 +46,16 @@ public class StarCommandServiceImpl implements StarCommandService {
 
     @Override
     public CreateStarResponseDTO createFirstStar(Long userId, MultipartFile htmlFile, String title, String siteUrl){
+        System.out.println("--------1-----------"+ userId);
+
         UserNode userNode = userNodeRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
+        System.out.println("--------1.5-----------");
+
         String htmlFileKey = s3Service.saveHtmlFile(htmlFile, title);
+
+        System.out.println("--------2-----------");
 
         Star star = Star.builder()
                 .title(title)
@@ -62,13 +68,22 @@ public class StarCommandServiceImpl implements StarCommandService {
             throw new GeneralException(ErrorStatus._STAR_CREATION_FAILED);
         }
 
+        System.out.println("--------3-----------");
+
         try {
             // AI 기능 호출 (썸네일 및 추천 키워드 생성)
             GetThumbnailAndKeywordsResponseDTO responseDTO = aiService.analyzeHtmlFile(savedStar.getId(), userId, htmlFileKey);
 
+            System.out.println("--------4-----------");
+
             // 유저 노드와 관계 설정 후 저장
             userNode.getStars().add(savedStar);
             userNodeRepository.save(userNode);
+
+            // 유저 스타 수정 횟수 증가
+            aiService.checkUpdatedNum(userNode);
+
+            System.out.println("--------5-----------");
 
             return CreateStarResponseDTO.builder()
                     .starId(savedStar.getId())
@@ -83,39 +98,7 @@ public class StarCommandServiceImpl implements StarCommandService {
         }
     }
 
-//    @Override
-//    public CreateStarResponseDTO createStar(User user, CreateStarFileDTO requestDTO){
-//        CreateStarRequestDTO starRequestDTO = requestDTO.getStarRequestDTO();
-//
-//        UserNode userNode = userNodeRepository.findById(user.getId())
-//                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
-//
-//        // 스타 생성 및 유저와 관계 설정
-//        Star star = createStarEntity(requestDTO, userNode);
-//
-//        // 카테고리 관계 설정
-//        categoryCommandService.linkStarToCategory(star, starRequestDTO.getCategoryName());
-//
-//        // 키워드 생성 및 관계 설정
-//        keywordCommandService.linkStarToKeywords(star, starRequestDTO.getKeywordList());
-//
-//        // 키워드+ 카테고리 포함된 스타를 다시 조회
-//        Star savedStar = starRepository.findById(star.getId())
-//                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
-//
-//        // 스타 간 Link 노드 생성
-//        linkCommandService.createLinksForStar(savedStar);
-//
-//        return CreateStarResponseDTO.builder()
-//                .starId(star.getId())
-//                .title(star.getTitle())
-//                .categoryName(starRequestDTO.getCategoryName())
-//                .keywordList(savedStar.getKeywords().stream()
-//                        .map(Keyword::getName)
-//                        .collect(Collectors.toList()))
-//                .build();
-//
-//    }
+
 
     @Override
     public PutStarResponseDTO createCompleteStar(UUID starId, CreateStarRequestDTO requestDTO){

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -16,7 +16,6 @@ import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.PutStarResponseDTO;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.domain.star.repository.StarRepository;
-import com.team_nebula.nebula.domain.user.entity.User;
 import com.team_nebula.nebula.domain.user.entity.UserNode;
 import com.team_nebula.nebula.domain.user.repository.neo4j.UserNodeRepository;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
@@ -46,16 +45,11 @@ public class StarCommandServiceImpl implements StarCommandService {
 
     @Override
     public CreateStarResponseDTO createFirstStar(Long userId, MultipartFile htmlFile, String title, String siteUrl){
-        System.out.println("--------1-----------"+ userId);
 
         UserNode userNode = userNodeRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-        System.out.println("--------1.5-----------");
-
         String htmlFileKey = s3Service.saveHtmlFile(htmlFile, title);
-
-        System.out.println("--------2-----------");
 
         Star star = Star.builder()
                 .title(title)
@@ -68,13 +62,9 @@ public class StarCommandServiceImpl implements StarCommandService {
             throw new GeneralException(ErrorStatus._STAR_CREATION_FAILED);
         }
 
-        System.out.println("--------3-----------");
-
         try {
             // AI 기능 호출 (썸네일 및 추천 키워드 생성)
             GetThumbnailAndKeywordsResponseDTO responseDTO = aiService.analyzeHtmlFile(savedStar.getId(), userId, htmlFileKey);
-
-            System.out.println("--------4-----------");
 
             // 유저 노드와 관계 설정 후 저장
             userNode.getStars().add(savedStar);
@@ -82,8 +72,6 @@ public class StarCommandServiceImpl implements StarCommandService {
 
             // 유저 스타 수정 횟수 증가
             aiService.checkUpdatedNum(userNode);
-
-            System.out.println("--------5-----------");
 
             return CreateStarResponseDTO.builder()
                     .starId(savedStar.getId())
@@ -132,30 +120,7 @@ public class StarCommandServiceImpl implements StarCommandService {
     }
 
 
-//    public Star createStarEntity(CreateStarFileDTO requestDTO, UserNode userNode){
-//        CreateStarRequestDTO starRequestDTO = requestDTO.getStarRequestDTO();
-//
-//        Star star = Star.builder()
-//                .thumbnailUrl(s3Service.saveThumbnail(requestDTO.getThumbnailImage(), starRequestDTO.getTitle()))
-//                .htmlFileUrl(s3Service.saveHtmlFile(requestDTO.getHtmlFile(), starRequestDTO.getTitle()))
-//                .summaryAI(starRequestDTO.getSummaryAI())
-//                .userMemo(starRequestDTO.getUserMemo())
-//                .views(0)
-//                .embedding(starRequestDTO.getEmbedding())
-//                .build();
-//
-//        Star savedStar = starRepository.save(star);
-//        if (savedStar.getId() == null) {
-//            throw new GeneralException(ErrorStatus._STAR_CREATION_FAILED);
-//        }
-//
-//        // 유저 노드와 관계 설정 후 저장
-//        userNode.getStars().add(savedStar);
-//        userNodeRepository.save(userNode);
-//
-//        return savedStar;
-//    }
-
+    @Override
     public GetStarOneResponseDTO updateStar(UUID starId, UpdateStarOneRequestDTO requestDTO){
         Star star = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));

--- a/src/main/java/com/team_nebula/nebula/domain/user/entity/UserNode.java
+++ b/src/main/java/com/team_nebula/nebula/domain/user/entity/UserNode.java
@@ -25,8 +25,8 @@ public class UserNode extends BaseEntity {
 	@Id
 	private Long userId;
 
-	@Property(name = "updatedNum")
-	private int updatedNum;
+	@Property(name = "updatedCnt")
+	private int updatedCnt;
 
 	@Relationship(type = "CREATED", direction = Relationship.Direction.OUTGOING)
 	private Set<Star> stars = new HashSet<>();
@@ -37,5 +37,10 @@ public class UserNode extends BaseEntity {
 	@Builder
 	public UserNode(Long userId) {
 		this.userId = userId;
+		this.updatedCnt = 0;
+	}
+
+	public void updateUpdatedCnt() {
+		this.updatedCnt++;
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/user/entity/UserNode.java
+++ b/src/main/java/com/team_nebula/nebula/domain/user/entity/UserNode.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.springframework.data.neo4j.core.schema.Id;
 import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Property;
 import org.springframework.data.neo4j.core.schema.Relationship;
 
 import com.team_nebula.nebula.domain.category.entity.Category;
@@ -23,6 +24,9 @@ public class UserNode extends BaseEntity {
 
 	@Id
 	private Long userId;
+
+	@Property(name = "updatedNum")
+	private int updatedNum;
 
 	@Relationship(type = "CREATED", direction = Relationship.Direction.OUTGOING)
 	private Set<Star> stars = new HashSet<>();

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
@@ -14,8 +14,11 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -95,25 +98,37 @@ public class AiService {
             // 50단위로 초기화
             int dividedCnt = (updatedCnt % 50);
 
-            System.out.println("------- Keyword Sync AI 호출 전----------");
 
             if (isFibonacciNumber(dividedCnt)) {
-                Map<String, Object> requestBody = new HashMap<>();
-                requestBody.put("user_id", String.valueOf(userNode.getUserId()));
+                String sendUserId = String.valueOf(userId);
 
-                System.out.println("------- Keyword Sync AI 호출 시작----------");
+                URI uri = UriComponentsBuilder.fromUriString(aiKeywordSyncUrl)
+                        .queryParam("user_id", sendUserId)
+                        .build()
+                        .toUri();
 
                 webClient.post()
-                        .uri(aiKeywordSyncUrl)
+                        .uri(uri)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .bodyValue(requestBody)
                         .retrieve()
+                        .onStatus(HttpStatusCode::is4xxClientError, response ->
+                                response.bodyToMono(String.class)
+                                        .map(body -> {
+                                            log.error("Keyword sync 응답 본문: {}", body);
+                                            return new WebClientResponseException(
+                                                    response.statusCode().value(),
+                                                    "Unprocessable Entity",
+                                                    null,
+                                                    body.getBytes(),
+                                                    null
+                                            );
+                                        })
+                        )
                         .bodyToMono(Void.class)
                         .doOnSuccess(response -> log.info("Keyword sync 성공: userId={}", userNode.getUserId()))
                         .doOnError(e -> log.error("Keyword sync 실패: {}", e.getMessage()))
                         .subscribe();
             }
-            System.out.println("------- Keyword Sync AI 호출 끝----------");
             userNodeRepository.save(userNode);
         }catch(Exception e) {
             throw new GeneralException(ErrorStatus._AI_KEYWORD_SYNC_ERROR);

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
@@ -1,6 +1,7 @@
 package com.team_nebula.nebula.global.AI.service;
 
 import com.team_nebula.nebula.domain.user.entity.UserNode;
+import com.team_nebula.nebula.domain.user.repository.neo4j.UserNodeRepository;
 import com.team_nebula.nebula.global.AI.dto.GetThumbnailAndKeywordsResponseDTO;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
@@ -34,10 +35,7 @@ public class AiService {
 
     private final WebClient webClient;
 
-    @Autowired
-    public AiService(WebClient.Builder webClientBuilder) {
-        this.webClient = webClientBuilder.build();
-    }
+    private final UserNodeRepository userNodeRepository;
 
     public GetThumbnailAndKeywordsResponseDTO analyzeHtmlFile(UUID starId, Long userId, String htmlFileKey) {
         try {
@@ -84,7 +82,10 @@ public class AiService {
 //    }
 
     @Async
-    public void checkUpdatedCnt(UserNode userNode) {
+    public void checkUpdatedCnt(Long userId) {
+
+        UserNode userNode = userNodeRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
         try {
             userNode.updateUpdatedCnt();
@@ -112,8 +113,8 @@ public class AiService {
                         .doOnError(e -> log.error("Keyword sync 실패: {}", e.getMessage()))
                         .subscribe();
             }
-
             System.out.println("------- Keyword Sync AI 호출 끝----------");
+            userNodeRepository.save(userNode);
         }catch(Exception e) {
             throw new GeneralException(ErrorStatus._AI_KEYWORD_SYNC_ERROR);
         }

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
@@ -12,7 +12,6 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -82,24 +81,43 @@ public class AiService {
 //                .onErrorMap(e -> new GeneralException(ErrorStatus._AI_EXTRACT_DATA_ERROR));
 //    }
 
-    public Mono<Void> checkUpdatedNum(UserNode userNode) {
-        userNode.updateUpdatedCnt();
+    public void checkUpdatedNum(UserNode userNode) {
 
-        // 50단위로 호출, 증가할때는 피보나치 수열
-        if (userNode.getUpdatedCnt() >= 50) {
-            Map<String, Object> requestBody = new HashMap<>();
-            requestBody.put("user_id", String.valueOf(userNode.getUserId()));
+        try {
+            userNode.updateUpdatedCnt();
 
-            return webClient.post()
-                    .uri(aiKeywordSyncUrl)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .bodyValue(requestBody)
-                    .retrieve()
-                    .bodyToMono(Void.class)
-                    .doOnSuccess(response -> log.info("Keyword sync 성공: userId={}", userNode.getUserId()))
-                    .doOnError(e -> log.error("Keyword sync 실패: {}", e.getMessage()))
-                    .onErrorMap(e -> new GeneralException(ErrorStatus._AI_KEYWORD_SYNC_ERROR));
+            int updatedCnt = userNode.getUpdatedCnt();
+            // 50단위로 초기화
+            int dividedCnt = (updatedCnt % 50);
+
+            if (isFibonacciNumber(dividedCnt)) {
+                Map<String, Object> requestBody = new HashMap<>();
+                requestBody.put("user_id", String.valueOf(userNode.getUserId()));
+
+                webClient.post()
+                        .uri(aiKeywordSyncUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .bodyValue(requestBody)
+                        .retrieve()
+                        .bodyToMono(Void.class)
+                        .doOnSuccess(response -> log.info("Keyword sync 성공: userId={}", userNode.getUserId()))
+                        .doOnError(e -> log.error("Keyword sync 실패: {}", e.getMessage()));
+            }
+        }catch(Exception e) {
+            throw new GeneralException(ErrorStatus._AI_KEYWORD_SYNC_ERROR);
         }
-        return Mono.empty();
+    }
+
+    // updatedCnt가 피보나치 수열에 해당되 true
+    private boolean isFibonacciNumber(int num) {
+        if (num < 0) return false;
+
+        int a = 0, b = 1;
+        while (b < num) {
+            int temp = a + b;
+            a = b;
+            b = temp;
+        }
+        return b == num;
     }
 }

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
@@ -49,6 +49,8 @@ public class AiService {
 
             HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(requestBody, headers);
 
+            System.out.println("--------3.1-----------");
+
             // AI 서버 요청 및 응답 받기
             ResponseEntity<GetThumbnailAndKeywordsResponseDTO> responseEntity = restTemplate.exchange(
                     aiExtractDataUrl,
@@ -56,6 +58,8 @@ public class AiService {
                     requestEntity,
                     GetThumbnailAndKeywordsResponseDTO.class
             );
+            System.out.println("--------3.2-----------");
+
 
             return responseEntity.getBody();
         } catch (Exception e) {

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
@@ -9,9 +9,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -81,18 +83,24 @@ public class AiService {
 //                .onErrorMap(e -> new GeneralException(ErrorStatus._AI_EXTRACT_DATA_ERROR));
 //    }
 
-    public void checkUpdatedNum(UserNode userNode) {
+    @Async
+    public void checkUpdatedCnt(UserNode userNode) {
 
         try {
             userNode.updateUpdatedCnt();
 
             int updatedCnt = userNode.getUpdatedCnt();
+
             // 50단위로 초기화
             int dividedCnt = (updatedCnt % 50);
+
+            System.out.println("------- Keyword Sync AI 호출 전----------");
 
             if (isFibonacciNumber(dividedCnt)) {
                 Map<String, Object> requestBody = new HashMap<>();
                 requestBody.put("user_id", String.valueOf(userNode.getUserId()));
+
+                System.out.println("------- Keyword Sync AI 호출 시작----------");
 
                 webClient.post()
                         .uri(aiKeywordSyncUrl)
@@ -101,8 +109,11 @@ public class AiService {
                         .retrieve()
                         .bodyToMono(Void.class)
                         .doOnSuccess(response -> log.info("Keyword sync 성공: userId={}", userNode.getUserId()))
-                        .doOnError(e -> log.error("Keyword sync 실패: {}", e.getMessage()));
+                        .doOnError(e -> log.error("Keyword sync 실패: {}", e.getMessage()))
+                        .subscribe();
             }
+
+            System.out.println("------- Keyword Sync AI 호출 끝----------");
         }catch(Exception e) {
             throw new GeneralException(ErrorStatus._AI_KEYWORD_SYNC_ERROR);
         }

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
@@ -49,8 +49,6 @@ public class AiService {
 
             HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(requestBody, headers);
 
-            System.out.println("--------3.1-----------");
-
             // AI 서버 요청 및 응답 받기
             ResponseEntity<GetThumbnailAndKeywordsResponseDTO> responseEntity = restTemplate.exchange(
                     aiExtractDataUrl,
@@ -58,8 +56,6 @@ public class AiService {
                     requestEntity,
                     GetThumbnailAndKeywordsResponseDTO.class
             );
-            System.out.println("--------3.2-----------");
-
 
             return responseEntity.getBody();
         } catch (Exception e) {

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
@@ -1,14 +1,18 @@
 package com.team_nebula.nebula.global.AI.service;
 
+import com.team_nebula.nebula.domain.user.entity.UserNode;
 import com.team_nebula.nebula.global.AI.dto.GetThumbnailAndKeywordsResponseDTO;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +25,18 @@ public class AiService {
 
     @Value("${ai.url.extract-data}")
     private String aiExtractDataUrl;
+
+    @Value("${ai.url.keyword-sync}")
+    private String aiKeywordSyncUrl;
+
     private final RestTemplate restTemplate = new RestTemplate();
+
+    private final WebClient webClient;
+
+    @Autowired
+    public AiService(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.build();
+    }
 
     public GetThumbnailAndKeywordsResponseDTO analyzeHtmlFile(UUID starId, Long userId, String htmlFileKey) {
         try {
@@ -48,5 +63,43 @@ public class AiService {
             log.error("AI 서버 요청 실패: {}", e.getMessage());
             throw new GeneralException(ErrorStatus._AI_EXTRACT_DATA_ERROR);
         }
+    }
+
+//    public Mono<GetThumbnailAndKeywordsResponseDTO> analyzeHtmlFile(UUID starId, Long userId, String htmlFileKey) {
+//        Map<String, Object> requestBody = new HashMap<>();
+//        requestBody.put("id", String.valueOf(starId));
+//        requestBody.put("user_id", String.valueOf(userId));
+//        requestBody.put("s3_key", htmlFileKey);
+//
+//        return webClient.post()
+//                .uri(aiExtractDataUrl)
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .bodyValue(requestBody)
+//                .retrieve()
+//                .bodyToMono(GetThumbnailAndKeywordsResponseDTO.class)
+//                .doOnSuccess(response -> log.info("AI 서버 응답 성공: {}", response))
+//                .doOnError(e -> log.error("AI 서버 요청 실패: {}", e.getMessage()))
+//                .onErrorMap(e -> new GeneralException(ErrorStatus._AI_EXTRACT_DATA_ERROR));
+//    }
+
+    public Mono<Void> checkUpdatedNum(UserNode userNode) {
+        userNode.updateUpdatedCnt();
+
+        // 50단위로 호출, 증가할때는 피보나치 수열
+        if (userNode.getUpdatedCnt() >= 50) {
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("user_id", String.valueOf(userNode.getUserId()));
+
+            return webClient.post()
+                    .uri(aiKeywordSyncUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .doOnSuccess(response -> log.info("Keyword sync 성공: userId={}", userNode.getUserId()))
+                    .doOnError(e -> log.error("Keyword sync 실패: {}", e.getMessage()))
+                    .onErrorMap(e -> new GeneralException(ErrorStatus._AI_KEYWORD_SYNC_ERROR));
+        }
+        return Mono.empty();
     }
 }

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	_AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5000","AI 서버에서 문제가 발생했습니다."),
 	_AI_EXTRACT_DATA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5001","AI에서 썸네일과 추천 키워드을 가져오지 못했습니다."),
+	_AI_KEYWORD_SYNC_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5002","AI Keyword sync 호출에 실해하였습니다."),
 
 	_S3_HTML_FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S35001", "S3에 저장된 html 파일을 삭제하는데 실패했습니다."),
 

--- a/src/main/java/com/team_nebula/nebula/global/config/AsyncConfig.java
+++ b/src/main/java/com/team_nebula/nebula/global/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.team_nebula.nebula.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);  // 동시에 실행할 수 있는 최소 스레드 개수
+        executor.setMaxPoolSize(10);  // 최대 스레드 개수
+        executor.setQueueCapacity(100); // 큐 크기
+        executor.setThreadNamePrefix("Async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/team_nebula/nebula/global/config/WebClientConfig.java
+++ b/src/main/java/com/team_nebula/nebula/global/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.team_nebula.nebula.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .build();
+    }
+}


### PR DESCRIPTION
## 💡 개요
유저 스타 작업 체크 기능 구현 + 스타 수정할 경우 링크 재설정 오류 수정

## 🔨작업 사항
### 1. 유저 스타 작업 체크 기능 구현
![image](https://github.com/user-attachments/assets/2d8750f9-ca82-4a8d-9553-442d0e7b3c92)
- 작업(스타 생성, 수정, 삭제)횟수를 체크할 updatedCnt를추가
- 스타 생성, 수정 ,삭제하는 서비스단에 Keyword-Sync AI 기능 호출하면서 증가시킴

<hr>

### 2.Keyword-Sync AI 호출 기능 구현
```
// 유저 스타 작업 횟수 증가
aiService.checkUpdatedCnt(userId);
```

```
@Async
    public void checkUpdatedCnt(Long userId) {

        UserNode userNode = userNodeRepository.findById(userId)
                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));

        try {
            userNode.updateUpdatedCnt();

            int updatedCnt = userNode.getUpdatedCnt();

            // 50단위로 초기화
            int dividedCnt = (updatedCnt % 50);


            if (isFibonacciNumber(dividedCnt)) {
                String sendUserId = String.valueOf(userId);

                URI uri = UriComponentsBuilder.fromUriString(aiKeywordSyncUrl)
                        .queryParam("user_id", sendUserId)
                        .build()
                        .toUri();

                webClient.post()
                        .uri(uri)
                        .contentType(MediaType.APPLICATION_JSON)
                        .retrieve()
                        .onStatus(HttpStatusCode::is4xxClientError, response ->
                                response.bodyToMono(String.class)
                                        .map(body -> {
                                            log.error("Keyword sync 응답 본문: {}", body);
                                            return new WebClientResponseException(
                                                    response.statusCode().value(),
                                                    "Unprocessable Entity",
                                                    null,
                                                    body.getBytes(),
                                                    null
                                            );
                                        })
                        )
                        .bodyToMono(Void.class)
                        .doOnSuccess(response -> log.info("Keyword sync 성공: userId={}", userNode.getUserId()))
                        .doOnError(e -> log.error("Keyword sync 실패: {}", e.getMessage()))
                        .subscribe();
            }
            userNodeRepository.save(userNode);
        }catch(Exception e) {
            throw new GeneralException(ErrorStatus._AI_KEYWORD_SYNC_ERROR);
        }
    }

    // updatedCnt가 피보나치 수열에 해당되 true
    private boolean isFibonacciNumber(int num) {
        if (num < 0) return false;

        int a = 0, b = 1;
        while (b < num) {
            int temp = a + b;
            a = b;
            b = temp;
        }
        return b == num;
    }
```
- 작업 횟수 체크 기능은 메인 기능이 처리되고 가장 마지막에 실행되기 때문에 checkUpdatedCnt가 실행 다 되기까지 Response를 기다리는게 비효율적이라고 생각함
- 그래서 @Async를 통해 비동기로 처리하는 로직으로 구현
- updatedCnt가 피보나치 수열에 해당하는 숫자면 Keyword-Sync를 호출하는 조건임
- 피보나치 수열은 간단히 구현했지만 더 효율적인 로직이 있으면 디벨롭할 예정
- 이번에 AI기능 호출할 때 webClient을 사용함.  새로운 스레드에서 실행된 @Async 메서드 안에서, WebClient가 논블로킹으로 HTTP 요청을 보냄으로써 성능을 극대화할수 있다고 판단했기 때문
- 이 로직이 성능이 더 좋다고 확인되면 다른 메소드에도 적용할 예정

<hr>



### 3. 스타의 키워드 수정 시 링크 노드 재설정 오류 수정
```
@Override
    public void updateKeywordsForStar(Star star, List<String> newKeywordNames) {
        // 키워드와 스타 연결 업데이트
        Star updateStar = keywordRepository.removeLinkAndReconnect(star.getId(), newKeywordNames);
        // 링크 재설정
        linkrepository.updateLinksBetweenStars(updateStar.getId());
    }
```
- 스타 정보 수정 기능을 수행할때 키워드가 수정되면 키워드 유사도가 달라지기 때문에 링크 재설정이 필요
- 그래서 먼저 기존 키워드 관계 삭제, 새로운 키워드 생성 및 관계 설정을 하고
- 키워드 유사도 체크해서 링크 노드 생성을 하는 흐름임


## 📝 기타 (선택)
- 오류는 등잔 밑에 있다.