### PR TITLE
SCRUM 176 : 스타 수정 최신화 오류 및 스타 삭제 후 링크 조회 오류 수정

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -22,14 +22,8 @@ public interface KeywordRepository extends Neo4jRepository<Keyword, String> {
     @Query("""
         MATCH (s:Star {id: $starId})-[t:TAGGED]->(:Keyword)
         DELETE t
-    
-        WITH s
-        UNWIND apoc.coll.toSet($keywordNames) AS keywordName
-        MERGE (k:Keyword {name: keywordName})
-        MERGE (s)-[:TAGGED]->(k)
-        RETURN s;
     """)
-    Star removeLinkAndReconnect(@Param("starId") UUID starId, @Param("keywordNames") List<String> keywordNames);
+    void removeOldKeywords(@Param("starId") UUID starId);
 
     @Query("""
         MATCH (k:Keyword)

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
@@ -21,7 +21,7 @@ public class KeywordCommandServiceImpl implements KeywordCommandService {
 
     private final KeywordRepository keywordRepository;
     private final LinkRepository linkrepository;
-    private final StarRepository starrepository;
+    private final StarRepository starRepository;
 
     @Override
     public void linkStarToKeywords(Star star, List<String> keywordNames) {
@@ -38,10 +38,14 @@ public class KeywordCommandServiceImpl implements KeywordCommandService {
 
     @Override
     public void updateKeywordsForStar(Star star, List<String> newKeywordNames) {
-        // 키워드와 스타 연결 업데이트
-        Star updateStar = keywordRepository.removeLinkAndReconnect(star.getId(), newKeywordNames);
-        // 링크 재설정
-        linkrepository.updateLinksBetweenStars(updateStar.getId());
+        // 키워드와 스타 연결 전부 삭제
+        keywordRepository.removeOldKeywords(star.getId());
+        // 새로운 키워드와 스타 연결
+        keywordRepository.linkStarToKeywords(star.getId(), newKeywordNames);
+        // 링크 노드 전부 삭제
+        linkrepository.deleteOldLinks(star.getId());
+        // 링크 노드 재설정
+        linkrepository.createLinksBetweenStars(star.getId());
     }
 
     @Override

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -2,6 +2,7 @@ package com.team_nebula.nebula.domain.link.repository;
 
 import com.team_nebula.nebula.domain.link.entity.Link;
 import com.team_nebula.nebula.domain.star.dto.response.GetLinkOneResponseDTO;
+import com.team_nebula.nebula.domain.star.entity.Star;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.data.neo4j.repository.query.Query;
 import org.springframework.data.repository.query.Param;
@@ -75,23 +76,9 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
     MATCH (s1:Star)-[r1:LINKED]->(l:Link)<-[r2:LINKED]-(s2)
     WHERE s1.id = $starId
     DELETE r1, r2
-    WITH s1,l
+    WITH l
     WHERE l IS NOT NULL
     DETACH DELETE l
-    
-    WITH s1
-    MATCH (s1)-[:TAGGED]->(k:Keyword)<-[:TAGGED]-(s2:Star)
-    WHERE s1 <> s2
-    AND (s1.isDeletedStatus = false OR s1.isDeletedStatus IS NULL)
-    AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
-    
-    WITH s1, s2, COUNT(k) AS sharedKeywordNum
-    WHERE sharedKeywordNum > 0
-    MERGE (l:Link {linked_two_node_Id: [s1.id, s2.id]})
-    ON CREATE SET l.sharedKeywordNum = sharedKeywordNum, l.similarityScore = 0.5, l.id = randomUUID()
-    MERGE (s1)-[:LINKED]->(l)
-    MERGE (s2)-[:LINKED]->(l)
     """)
-    void updateLinksBetweenStars(@Param("starId") UUID starId);
-
+    void deleteOldLinks(@Param("starId") UUID starId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -31,11 +31,8 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
     MATCH (u:UserNode)-[:CREATED]->(s:Star)
     WHERE u.userId = $userId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
 
-    MATCH (s)-[:LINKED]->(l:Link)
-    WHERE EXISTS {
-        MATCH (s2:Star)-[:LINKED]->(l)
-        WHERE (u)-[:CREATED]->(s2)
-    }
+    MATCH (s)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
+    WHERE (u)-[:CREATED]->(s2) AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
 
     RETURN DISTINCT l.id AS linkId,
                     l.linked_two_node_Id AS linkedNodeIdList,
@@ -49,7 +46,7 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
     WHERE u.userId = $userId AND c.id = $categoryId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
     
     MATCH (s)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
-    WHERE (u)-[:CREATED]->(s2)
+    WHERE (u)-[:CREATED]->(s2) AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
     
     RETURN l.id AS linkId,
            l.linked_two_node_Id AS linkedNodeIdList,
@@ -63,7 +60,7 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
     WHERE u.userId = $userId AND k.name = $keywordId AND (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
     
     MATCH (s)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
-    WHERE (u)-[:CREATED]->(s2)
+    WHERE (u)-[:CREATED]->(s2) AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
     
     RETURN l,
            l.linked_two_node_Id AS linkedNodeIdList,

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/UpdateStarOneRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/UpdateStarOneRequestDTO.java
@@ -16,5 +16,5 @@ public class UpdateStarOneRequestDTO {
     String categoryName;
     String summaryAI;
     String userMemo;
-    List<String> keywords;
+    List<String> keywordList;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -123,35 +123,44 @@ public class StarCommandServiceImpl implements StarCommandService {
 
     @Override
     public GetStarOneResponseDTO updateStar(Long userId, UUID starId, UpdateStarOneRequestDTO requestDTO){
+
         Star star = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
+        // title, AI요약, 사용자 메모 업데이트
         Optional.ofNullable(requestDTO.getTitle()).ifPresent(star::updateTitle);
         Optional.ofNullable(requestDTO.getSummaryAI()).ifPresent(star::updateSummaryAI);
         Optional.ofNullable(requestDTO.getUserMemo()).ifPresent(star::updateUserMemo);
-        Optional.ofNullable(requestDTO.getKeywords()).ifPresent(keywords ->
-                keywordCommandService.updateKeywordsForStar(star, keywords));
 
+        // 카테고리 업데이트. 만약 수정되지 않으면 기존 카테고리 이름 반환
         String categoryName = Optional.ofNullable(requestDTO.getCategoryName())
                 .map(category -> categoryCommandService.linkStarToCategoryAndGetName(star, category))
                 .orElseGet(() -> categoryQueryService.findCategoryNameByStar(star.getId()));
 
-        Star updateStar = starRepository.findById(starId)
+        // 키워드 업데이트 -> 링크 재설정
+        Optional.ofNullable(requestDTO.getKeywordList()).ifPresent(keywords ->
+                keywordCommandService.updateKeywordsForStar(star, keywords));
+
+        // 업데이트된 최신 스타객체 조회
+        Star completedStar = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
+
+        // DB에 저장
+        Star updatedStar = starRepository.save(completedStar);
 
         // 유저 스타 작업 횟수 증가
         aiService.checkUpdatedCnt(userId);
 
         return GetStarOneResponseDTO.builder()
-                .starId(updateStar.getId())
+                .starId(updatedStar.getId())
                 .categoryName(categoryName)
-                .title(updateStar.getTitle())
-                .siteUrl(updateStar.getSiteUrl())
-                .thumbnailUrl(updateStar.getThumbnailUrl())
-                .summaryAI(updateStar.getSummaryAI())
-                .userMemo(updateStar.getUserMemo())
-                .views(updateStar.getViews())
-                .keywordList(updateStar.getKeywords().stream()
+                .title(updatedStar.getTitle())
+                .siteUrl(updatedStar.getSiteUrl())
+                .thumbnailUrl(updatedStar.getThumbnailUrl())
+                .summaryAI(updatedStar.getSummaryAI())
+                .userMemo(updatedStar.getUserMemo())
+                .views(updatedStar.getViews())
+                .keywordList(updatedStar.getKeywords().stream()
                         .map(Keyword::getName)
                         .toList())
                 .build();    

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -29,40 +29,6 @@ public class StarQueryServiceImpl implements StarQueryService {
     private final UserNodeRepository userNodeRepository;
     private final LinkQueryService linkQueryService;
 
-    // 스타 JSON 데이터 파싱
-//    @Override
-//    public CreateStarFileDTO starDataParsing(MultipartFile thumbnailImage, MultipartFile htmlFile, String starJsonData) {
-//        ObjectMapper objectMapper = new ObjectMapper();
-//
-//        // LocalDateTime 처리
-//        objectMapper.registerModule(new JavaTimeModule());
-//
-//        // 컨트롤문자 허용
-//        objectMapper.configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature(), true);
-//        // 작은따옴표 허용
-//        objectMapper.configure(JsonReadFeature.ALLOW_SINGLE_QUOTES.mappedFeature(), true);
-//        // \ 이스케이프 허용
-//        objectMapper.configure(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER.mappedFeature(), true);
-//
-//        CreateStarRequestDTO request;
-//        try {
-//            // 유니코드 깨짐 방지
-//            starJsonData = new String(starJsonData.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
-//
-//            request = objectMapper.readValue(starJsonData, CreateStarRequestDTO.class);
-//        } catch (Exception e) {
-//            e.printStackTrace();
-//            throw new RuntimeException("Invalid JSON format for starJsonData.");
-//        }
-//
-//        return CreateStarFileDTO.builder()
-//                .thumbnailImage(thumbnailImage)
-//                .htmlFile(htmlFile)
-//                .starRequestDTO(request)
-//                .build();
-//    }
-
-
     // 스타 + 링크 전체 조회
     @Override
     public GetStarListResponseDTO getStarList(Long userId){


### PR DESCRIPTION
## 💡 개요
스타 수정 최신화 오류 및 스타 삭제 후 링크 조회 오류 수정

## 🔨작업 사항
### 1. 스타 수정 최신화 오류 수정
StarCommandServiceImpl.java
```
@Override
    public GetStarOneResponseDTO updateStar(Long userId, UUID starId, UpdateStarOneRequestDTO requestDTO){

        Star star = starRepository.findById(starId)
                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));

        // title, AI요약, 사용자 메모 업데이트
        Optional.ofNullable(requestDTO.getTitle()).ifPresent(star::updateTitle);
        Optional.ofNullable(requestDTO.getSummaryAI()).ifPresent(star::updateSummaryAI);
        Optional.ofNullable(requestDTO.getUserMemo()).ifPresent(star::updateUserMemo);

        // 카테고리 업데이트. 만약 수정되지 않으면 기존 카테고리 이름 반환
        String categoryName = Optional.ofNullable(requestDTO.getCategoryName())
                .map(category -> categoryCommandService.linkStarToCategoryAndGetName(star, category))
                .orElseGet(() -> categoryQueryService.findCategoryNameByStar(star.getId()));

        // 키워드 업데이트 -> 링크 재설정
        Optional.ofNullable(requestDTO.getKeywordList()).ifPresent(keywords ->
                keywordCommandService.updateKeywordsForStar(star, keywords));

        // 업데이트된 최신 스타객체 조회
        Star completedStar = starRepository.findById(starId)
                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));

        // DB에 저장
        Star updatedStar = starRepository.save(completedStar);
```
- 기존 코드의 오류는 쿼리 상으로는 데이터를 변경해놓고 Response를 보내서 최신화된것 처럼 보이지만 다시 조회하는 경우 데이터가 최신화되지 않았다.
- 그래서 최신 업데이트된 스타객체를 조회하고 save를 해줬다.

<hr>

```
@Override
    public void updateKeywordsForStar(Star star, List<String> newKeywordNames) {
        // 키워드와 스타 연결 전부 삭제
        keywordRepository.removeOldKeywords(star.getId());
        // 새로운 키워드와 스타 연결
        keywordRepository.linkStarToKeywords(star.getId(), newKeywordNames);
        // 링크 노드 전부 삭제
        linkrepository.deleteOldLinks(star.getId());
        // 링크 노드 재설정
        linkrepository.createLinksBetweenStars(star.getId());
    }
```
- 기존 코드에서는 기존 키워드 삭제 및 재연결, 기존 링크 삭제 및 재연결로 나눠서 총 2개의 쿼리로 작업을 수행했지만 쿼리 기능을 합쳐서 실행해서 코드 복잡성이 증가하고 디버깅하기가 어려워졌다.
- 해결책으로 기능을 단계별로 나눠 쿼리를 독립적으로 수행하기했다.
- 쿼리로 DB호출이 많아져서 쿼리를 실행할 때마다 I/O 비용이 발생하고 데이터 무결성 문제를 쿼리 최적화를 통해 더 보완할 예정

<hr>

###  2. 스타 삭제 후 스타 조회할 경우 링크 오류

- 스타 삭제를 하고 삭제된 스타쪽으로 링크가 있는 문제가 발생함
- 쿼리상 오류로 조건 수정으로 문제해결

## 📝 기타 (선택)
- Cyper Query는 아직도 어렵다.