### PR TITLE
SCRUM-178 : 사용순 상위 키워드 10개 조회 기능 구현

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/keyword/api/KeywordController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/api/KeywordController.java
@@ -1,8 +1,8 @@
 package com.team_nebula.nebula.domain.keyword.api;
 
+import com.team_nebula.nebula.domain.keyword.dto.response.GetMostUsedKeywordListResponseDTO;
 import com.team_nebula.nebula.domain.keyword.service.KeywordCommandService;
 import com.team_nebula.nebula.domain.keyword.service.KeywordQueryService;
-import com.team_nebula.nebula.domain.user.entity.User;
 import com.team_nebula.nebula.global.annotation.AuthUser;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,5 +39,14 @@ public class KeywordController {
         String deleteMessage = keywordCommandService.deleteKeywords();
         return ApiResponse.onSuccess(deleteMessage);
     }
+
+    // 가장 많이 사용된 키워드 10개 조회 API
+    @Operation(summary = "사용순 상위 키워드 10개 조회", description = "가장 많이 사용되고 있는 상위 10개 키워드 이름리스트를 반환한다. 추가로 순위와 키워드가 사용된 횟수를 볼 수 있다.")
+    @GetMapping("/top10-used")
+    public ApiResponse<GetMostUsedKeywordListResponseDTO> getKeywords() {
+        GetMostUsedKeywordListResponseDTO mostUsedKeywordList = keywordQueryService.getMostUsedKeywordList();
+        return ApiResponse.onSuccess(mostUsedKeywordList);
+    }
+
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/dto/response/GetMostUsedKeywordListResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/dto/response/GetMostUsedKeywordListResponseDTO.java
@@ -1,0 +1,16 @@
+package com.team_nebula.nebula.domain.keyword.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class GetMostUsedKeywordListResponseDTO {
+    private List<GetMostUsedKeywordOneResponseDTO> mostUsedKeywordList;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/dto/response/GetMostUsedKeywordOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/dto/response/GetMostUsedKeywordOneResponseDTO.java
@@ -1,0 +1,15 @@
+package com.team_nebula.nebula.domain.keyword.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class GetMostUsedKeywordOneResponseDTO {
+    private String keywordName;
+    private int usedCnt;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -1,5 +1,6 @@
 package com.team_nebula.nebula.domain.keyword.repository;
 
+import com.team_nebula.nebula.domain.keyword.dto.response.GetMostUsedKeywordOneResponseDTO;
 import com.team_nebula.nebula.domain.keyword.entity.Keyword;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
@@ -39,5 +40,15 @@ public interface KeywordRepository extends Neo4jRepository<Keyword, String> {
         RETURN DISTINCT k.name
     """)
     List<String> getAllKeywordNames(@Param("userId") Long userId);
+
+    @Query("""
+    MATCH (k:Keyword)<-[:TAGGED]-(s:Star)
+    WHERE (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
+    RETURN k.name AS keywordName, COUNT(s) AS usedCnt
+    ORDER BY usedCnt DESC, keywordName ASC
+    LIMIT 10
+""")
+    List<GetMostUsedKeywordOneResponseDTO> getMostUsedKeywordList();
+
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordQueryService.java
@@ -1,8 +1,12 @@
 package com.team_nebula.nebula.domain.keyword.service;
 
 
+import com.team_nebula.nebula.domain.keyword.dto.response.GetMostUsedKeywordListResponseDTO;
+
 import java.util.List;
 
 public interface KeywordQueryService {
     List<String> getKeywords(Long userId);
+
+    GetMostUsedKeywordListResponseDTO getMostUsedKeywordList();
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/keywordQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/keywordQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.team_nebula.nebula.domain.keyword.service;
 
+import com.team_nebula.nebula.domain.keyword.dto.response.GetMostUsedKeywordListResponseDTO;
+import com.team_nebula.nebula.domain.keyword.dto.response.GetMostUsedKeywordOneResponseDTO;
 import com.team_nebula.nebula.domain.keyword.repository.KeywordRepository;
 import com.team_nebula.nebula.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -19,4 +21,14 @@ public class keywordQueryServiceImpl implements  KeywordQueryService {
     public List<String> getKeywords(Long userId){
         return keywordRepository.getAllKeywordNames(userId);
     }
+
+    @Override
+    public GetMostUsedKeywordListResponseDTO getMostUsedKeywordList(){
+        List<GetMostUsedKeywordOneResponseDTO> mostUsedKeywordList = keywordRepository.getMostUsedKeywordList();
+
+        return GetMostUsedKeywordListResponseDTO.builder()
+                .mostUsedKeywordList(mostUsedKeywordList)
+                .build();
+    }
+
 }


### PR DESCRIPTION
## 💡 개요
사용순 상위 키워드 10개 조회 기능 구현

## 🔨작업 사항
![image](https://github.com/user-attachments/assets/2784309b-6d2b-4c05-be64-0fbbc16cd7c1)
- 가장 많이 사용된 키워드(== 가장 많이 스타노드와 연결된 키워드 노드) 상위 10개를 조회
- 횟수가 동일하면 알파벳 순으로 조회