### PR TITLE
SCRUM 179 : 타유저의 스타와 링크 생성 오류 수정

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/keyword/api/KeywordController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/api/KeywordController.java
@@ -1,8 +1,8 @@
 package com.team_nebula.nebula.domain.keyword.api;
 
+import com.team_nebula.nebula.domain.keyword.dto.response.GetMostUsedKeywordListResponseDTO;
 import com.team_nebula.nebula.domain.keyword.service.KeywordCommandService;
 import com.team_nebula.nebula.domain.keyword.service.KeywordQueryService;
-import com.team_nebula.nebula.domain.user.entity.User;
 import com.team_nebula.nebula.global.annotation.AuthUser;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,5 +39,14 @@ public class KeywordController {
         String deleteMessage = keywordCommandService.deleteKeywords();
         return ApiResponse.onSuccess(deleteMessage);
     }
+
+    // 가장 많이 사용된 키워드 10개 조회 API
+    @Operation(summary = "사용순 상위 키워드 10개 조회", description = "가장 많이 사용되고 있는 상위 10개 키워드 이름리스트를 반환한다. 추가로 순위와 키워드가 사용된 횟수를 볼 수 있다.")
+    @GetMapping("/top10-used")
+    public ApiResponse<GetMostUsedKeywordListResponseDTO> getKeywords() {
+        GetMostUsedKeywordListResponseDTO mostUsedKeywordList = keywordQueryService.getMostUsedKeywordList();
+        return ApiResponse.onSuccess(mostUsedKeywordList);
+    }
+
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/dto/response/GetMostUsedKeywordListResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/dto/response/GetMostUsedKeywordListResponseDTO.java
@@ -1,0 +1,16 @@
+package com.team_nebula.nebula.domain.keyword.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class GetMostUsedKeywordListResponseDTO {
+    private List<GetMostUsedKeywordOneResponseDTO> mostUsedKeywordList;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/dto/response/GetMostUsedKeywordOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/dto/response/GetMostUsedKeywordOneResponseDTO.java
@@ -1,0 +1,15 @@
+package com.team_nebula.nebula.domain.keyword.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class GetMostUsedKeywordOneResponseDTO {
+    private String keywordName;
+    private int usedCnt;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -1,5 +1,6 @@
 package com.team_nebula.nebula.domain.keyword.repository;
 
+import com.team_nebula.nebula.domain.keyword.dto.response.GetMostUsedKeywordOneResponseDTO;
 import com.team_nebula.nebula.domain.keyword.entity.Keyword;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
@@ -39,5 +40,15 @@ public interface KeywordRepository extends Neo4jRepository<Keyword, String> {
         RETURN DISTINCT k.name
     """)
     List<String> getAllKeywordNames(@Param("userId") Long userId);
+
+    @Query("""
+    MATCH (k:Keyword)<-[:TAGGED]-(s:Star)
+    WHERE (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
+    RETURN k.name AS keywordName, COUNT(s) AS usedCnt
+    ORDER BY usedCnt DESC, keywordName ASC
+    LIMIT 10
+""")
+    List<GetMostUsedKeywordOneResponseDTO> getMostUsedKeywordList();
+
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -47,7 +47,7 @@ public interface KeywordRepository extends Neo4jRepository<Keyword, String> {
     RETURN k.name AS keywordName, COUNT(s) AS usedCnt
     ORDER BY usedCnt DESC, keywordName ASC
     LIMIT 10
-""")
+    """)
     List<GetMostUsedKeywordOneResponseDTO> getMostUsedKeywordList();
 
 

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandService.java
@@ -7,7 +7,7 @@ import java.util.List;
 public interface KeywordCommandService {
     public void linkStarToKeywords(Star star, List<String> keywordNames);
 
-    public void updateKeywordsForStar(Star star, List<String> newKeywordNames);
+    public void updateKeywordsForStar(Long userId, Star star, List<String> newKeywordNames);
 
     public String deleteKeywords();
     }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordCommandServiceImpl.java
@@ -37,7 +37,7 @@ public class KeywordCommandServiceImpl implements KeywordCommandService {
     }
 
     @Override
-    public void updateKeywordsForStar(Star star, List<String> newKeywordNames) {
+    public void updateKeywordsForStar(Long userId, Star star, List<String> newKeywordNames) {
         // 키워드와 스타 연결 전부 삭제
         keywordRepository.removeOldKeywords(star.getId());
         // 새로운 키워드와 스타 연결
@@ -45,7 +45,7 @@ public class KeywordCommandServiceImpl implements KeywordCommandService {
         // 링크 노드 전부 삭제
         linkrepository.deleteOldLinks(star.getId());
         // 링크 노드 재설정
-        linkrepository.createLinksBetweenStars(star.getId());
+        linkrepository.createLinksBetweenStars(userId, star.getId());
     }
 
     @Override

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/KeywordQueryService.java
@@ -1,8 +1,12 @@
 package com.team_nebula.nebula.domain.keyword.service;
 
 
+import com.team_nebula.nebula.domain.keyword.dto.response.GetMostUsedKeywordListResponseDTO;
+
 import java.util.List;
 
 public interface KeywordQueryService {
     List<String> getKeywords(Long userId);
+
+    GetMostUsedKeywordListResponseDTO getMostUsedKeywordList();
 }

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/service/keywordQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/service/keywordQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.team_nebula.nebula.domain.keyword.service;
 
+import com.team_nebula.nebula.domain.keyword.dto.response.GetMostUsedKeywordListResponseDTO;
+import com.team_nebula.nebula.domain.keyword.dto.response.GetMostUsedKeywordOneResponseDTO;
 import com.team_nebula.nebula.domain.keyword.repository.KeywordRepository;
 import com.team_nebula.nebula.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -19,4 +21,14 @@ public class keywordQueryServiceImpl implements  KeywordQueryService {
     public List<String> getKeywords(Long userId){
         return keywordRepository.getAllKeywordNames(userId);
     }
+
+    @Override
+    public GetMostUsedKeywordListResponseDTO getMostUsedKeywordList(){
+        List<GetMostUsedKeywordOneResponseDTO> mostUsedKeywordList = keywordRepository.getMostUsedKeywordList();
+
+        return GetMostUsedKeywordListResponseDTO.builder()
+                .mostUsedKeywordList(mostUsedKeywordList)
+                .build();
+    }
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -14,8 +14,8 @@ import java.util.UUID;
 public interface LinkRepository extends Neo4jRepository<Link, UUID> {
 
     @Query("""
-        MATCH (s1:Star)-[:TAGGED]->(k:Keyword)<-[:TAGGED]-(s2:Star)
-        WHERE s1.id = $starId AND s1 <> s2
+        MATCH (u:UserNode)-[:CREATED]->(s1:Star)-[:TAGGED]->(k:Keyword)<-[:TAGGED]-(s2:Star)<-[:CREATED]-(u)
+        WHERE u.userId=$userId AND s1.id = $starId AND s1 <> s2
         AND (s1.isDeletedStatus = false OR s1.isDeletedStatus IS NULL)
         AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
         WITH s1, s2, COUNT(k) AS sharedKeywordNum
@@ -25,7 +25,7 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
         MERGE (s1)-[:LINKED]->(l)
         MERGE (s2)-[:LINKED]->(l)
     """)
-    void createLinksBetweenStars(@Param("starId") UUID starId);
+    void createLinksBetweenStars(@Param("userId") Long userId, @Param("starId") UUID starId);
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkCommandService.java
@@ -4,5 +4,5 @@ import com.team_nebula.nebula.domain.star.entity.Star;
 
 public interface LinkCommandService {
 
-    public void createLinksForStar(Star star);
+    public void createLinksForStar(Long userId, Star star);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/link/service/LinkCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/service/LinkCommandServiceImpl.java
@@ -14,8 +14,8 @@ public class LinkCommandServiceImpl implements LinkCommandService{
     private final LinkRepository linkRepository;
 
     @Override
-    public void createLinksForStar(Star star) {
-        linkRepository.createLinksBetweenStars(star.getId());
+    public void createLinksForStar(Long userId, Star star) {
+        linkRepository.createLinksBetweenStars(userId, star.getId());
     }
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarController.java
@@ -58,8 +58,8 @@ public class StarController {
     // 스타 입력 완료 API(데이터 입력 후 나머지 노드 생성)
     @Operation(summary = "스타 입력 완료", description = "스타의 카테고리, 사용자메모, AI요약, 키워드를 입력하고 스타 정보 입력을 완료하는 API")
     @PatchMapping("/complete/{starId}")
-    public ApiResponse<PutStarResponseDTO> createCompleteStar(@PathVariable UUID starId, @RequestBody CreateStarRequestDTO requestDTO){
-        PutStarResponseDTO responseDTO = starCommandService.createCompleteStar(starId, requestDTO);
+    public ApiResponse<PutStarResponseDTO> createCompleteStar(@AuthUser Long userId, @PathVariable UUID starId, @RequestBody CreateStarRequestDTO requestDTO){
+        PutStarResponseDTO responseDTO = starCommandService.createCompleteStar(userId, starId, requestDTO);
 
         return ApiResponse.onSuccess(responseDTO);
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -14,7 +14,7 @@ public interface StarCommandService {
 
     public CreateStarResponseDTO createFirstStar(Long userId, MultipartFile htmlFile, String title, String siteUrl);
 
-    public PutStarResponseDTO createCompleteStar(UUID starId, CreateStarRequestDTO requestDTO);
+    public PutStarResponseDTO createCompleteStar(Long userId, UUID starId, CreateStarRequestDTO requestDTO);
 
     public GetStarOneResponseDTO updateStar(Long userId, UUID starId, UpdateStarOneRequestDTO requestDTO);
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -89,7 +89,7 @@ public class StarCommandServiceImpl implements StarCommandService {
 
 
     @Override
-    public PutStarResponseDTO createCompleteStar(UUID starId, CreateStarRequestDTO requestDTO){
+    public PutStarResponseDTO createCompleteStar(Long userId, UUID starId, CreateStarRequestDTO requestDTO){
 
         Star star = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
@@ -105,7 +105,7 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
         // 스타 간 Link 노드 생성
-        linkCommandService.createLinksForStar(savedStar);
+        linkCommandService.createLinksForStar(userId, savedStar);
 
         savedStar.updateStar(requestDTO.getThumbnailUrl(), requestDTO.getSummaryAI(), requestDTO.getUserMemo());
         starRepository.save(savedStar);
@@ -127,13 +127,6 @@ public class StarCommandServiceImpl implements StarCommandService {
         Star star = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
 
-        // title, AI요약, 사용자 메모 업데이트
-        Optional.ofNullable(requestDTO.getTitle()).ifPresent(star::updateTitle);
-        Optional.ofNullable(requestDTO.getSummaryAI()).ifPresent(star::updateSummaryAI);
-        Optional.ofNullable(requestDTO.getUserMemo()).ifPresent(star::updateUserMemo);
-        starRepository.save(star);
-
-
         // 카테고리 업데이트. 만약 수정되지 않으면 기존 카테고리 이름 반환
         String categoryName = Optional.ofNullable(requestDTO.getCategoryName())
                 .map(category -> categoryCommandService.linkStarToCategoryAndGetName(star, category))
@@ -141,12 +134,17 @@ public class StarCommandServiceImpl implements StarCommandService {
 
         // 키워드 업데이트 -> 링크 재설정
         Optional.ofNullable(requestDTO.getKeywordList()).ifPresent(keywords ->
-                keywordCommandService.updateKeywordsForStar(star, keywords));
+                keywordCommandService.updateKeywordsForStar(userId, star, keywords));
 
 
         // 업데이트된 최신 스타객체 조회
         Star latestStar = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
+
+        // title, AI요약, 사용자 메모 업데이트
+        Optional.ofNullable(requestDTO.getTitle()).ifPresent(latestStar::updateTitle);
+        Optional.ofNullable(requestDTO.getSummaryAI()).ifPresent(latestStar::updateSummaryAI);
+        Optional.ofNullable(requestDTO.getUserMemo()).ifPresent(latestStar::updateUserMemo);
 
         // DB에 저장
         Star updatedStar = starRepository.save(latestStar);


### PR DESCRIPTION
## 💡 개요
타유저의 스타와 링크 생성 오류 수정

## 🔨작업 사항
- 기존 코드에서 다른 사용자와 키워드를 공유하는 경우 자기의 스타노드와 아닌 스타와 링크가 생기는 오류가 발생함
- 링크 재설정 경우 스타id로만 생성해서 생기는 오류였음
- 그래서 유저id도 쿼리 조건에 추가해서 오류해결


