### PR TITLE
SCURM 187 : 링크 노드에 공유 키워드 리스트 추가 및 기능 수정

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/link/converter/LinkConverter.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/converter/LinkConverter.java
@@ -8,6 +8,7 @@ public class LinkConverter {
         return GetLinkOneResponseDTO.builder()
                 .linkId(data.getLinkId())
                 .sharedKeywordNum(data.getSharedKeywordNum())
+                .sharedKeywords(data.getSharedKeywords())
                 .similarity(data.getSimilarity())
                 .linkedNodeIdList(data.getLinkedNodeIdList())
                 .build();

--- a/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/entity/Link.java
@@ -22,6 +22,9 @@ public class Link extends BaseEntity {
     @Property("sharedKeywordNum")
     private int sharedKeywordNum;
 
+    @Property("sharedKeywords")
+    private List<String> sharedKeywords;
+
     @Property("similarityScore")
     private double similarityScore;
 
@@ -29,10 +32,11 @@ public class Link extends BaseEntity {
     private List<UUID> linkedNode;
 
     @Builder
-    public Link(int sharedKeywordNum, double similarityScore, List<UUID> linkedNode) {
+    public Link(int sharedKeywordNum, double similarityScore, List<UUID> linkedNode, List<String> sharedKeywords) {
         this.id = UUID.randomUUID();
         this.sharedKeywordNum = sharedKeywordNum;
         this.similarityScore = similarityScore;
         this.linkedNode = linkedNode;
+        this.sharedKeywords = sharedKeywords;
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -33,10 +33,13 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
 
     MATCH (s)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
     WHERE (u)-[:CREATED]->(s2) AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
+    
+    MATCH (s)-[:TAGGED]->(k:Keyword)<-[:TAGGED]-(s2)
 
     RETURN DISTINCT l.id AS linkId,
                     l.linked_two_node_Id AS linkedNodeIdList,
                     l.sharedKeywordNum AS sharedKeywordNum,
+                    COLLECT(DISTINCT k.name) AS sharedKeywords,
                     l.similarityScore AS similarity
     """)
     List<GetLinkOneResponseDTO> findLinksByUserId(@Param("userId") Long userId);
@@ -48,9 +51,13 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
     MATCH (s)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
     WHERE (u)-[:CREATED]->(s2) AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
     
+    MATCH (s)-[:TAGGED]->(k:Keyword)<-[:TAGGED]-(s2)
+
+    
     RETURN l.id AS linkId,
            l.linked_two_node_Id AS linkedNodeIdList,
            l.sharedKeywordNum AS sharedKeywordNum,
+           COLLECT(DISTINCT k.name) AS sharedKeywords,
            l.similarityScore AS similarity
     """)
     List<GetLinkOneResponseDTO> findLinkInCategory(@Param("userId") Long userId, @Param("categoryId") UUID categoryId);
@@ -62,9 +69,13 @@ public interface LinkRepository extends Neo4jRepository<Link, UUID> {
     MATCH (s)-[:LINKED]->(l:Link)<-[:LINKED]-(s2:Star)
     WHERE (u)-[:CREATED]->(s2) AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
     
+    MATCH (s)-[:TAGGED]->(kShared:Keyword)<-[:TAGGED]-(s2)
+
+    
     RETURN l,
            l.linked_two_node_Id AS linkedNodeIdList,
            l.sharedKeywordNum AS sharedKeywordNum,
+           COLLECT(DISTINCT kShared.name) AS sharedKeywords,
            l.similarityScore AS similarity
     """)
     List<GetLinkOneResponseDTO> findLinkInKeyword(@Param("userId") Long userId, @Param("keywordId") String keywordId);

--- a/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/link/repository/LinkRepository.java
@@ -14,18 +14,26 @@ import java.util.UUID;
 public interface LinkRepository extends Neo4jRepository<Link, UUID> {
 
     @Query("""
-        MATCH (u:UserNode)-[:CREATED]->(s1:Star)-[:TAGGED]->(k:Keyword)<-[:TAGGED]-(s2:Star)<-[:CREATED]-(u)
-        WHERE u.userId=$userId AND s1.id = $starId AND s1 <> s2
-        AND (s1.isDeletedStatus = false OR s1.isDeletedStatus IS NULL)
-        AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
-        WITH s1, s2, COUNT(k) AS sharedKeywordNum
-        WHERE sharedKeywordNum > 0
-        MERGE (l:Link {linked_two_node_Id: [s1.id, s2.id]})
-        ON CREATE SET l.sharedKeywordNum = sharedKeywordNum, l.similarityScore = 0.5, l.id = randomUUID()
-        MERGE (s1)-[:LINKED]->(l)
-        MERGE (s2)-[:LINKED]->(l)
+    MATCH (u:UserNode)-[:CREATED]->(s1:Star)-[:TAGGED]->(k:Keyword)<-[:TAGGED]-(s2:Star)<-[:CREATED]-(u)
+    WHERE u.userId = $userId AND s1.id = $starId AND s1 <> s2
+    AND (s1.isDeletedStatus = false OR s1.isDeletedStatus IS NULL)
+    AND (s2.isDeletedStatus = false OR s2.isDeletedStatus IS NULL)
+    
+    WITH s1, s2, COLLECT(DISTINCT k.name) AS sharedKeywords, COUNT(DISTINCT k) AS sharedKeywordNum
+    WHERE sharedKeywordNum > 0
+
+    MERGE (l:Link {linked_two_node_Id: [s1.id, s2.id]})
+    ON CREATE SET
+        l.id = randomUUID(),
+        l.sharedKeywordNum = sharedKeywordNum,
+        l.similarityScore = 0.5,
+        l.sharedKeywords = sharedKeywords
+
+    MERGE (s1)-[:LINKED]->(l)
+    MERGE (s2)-[:LINKED]->(l)
     """)
     void createLinksBetweenStars(@Param("userId") Long userId, @Param("starId") UUID starId);
+
 
     @Query("""
     MATCH (u:UserNode)-[:CREATED]->(s:Star)

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetLinkOneResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/GetLinkOneResponseDTO.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 public class GetLinkOneResponseDTO {
     private UUID linkId;
     private int sharedKeywordNum;
+    private List<String> sharedKeywords;
     private double similarity;
     private List<UUID> linkedNodeIdList;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -170,6 +170,7 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .summaryAI(updatedStar.getSummaryAI())
                 .userMemo(updatedStar.getUserMemo())
                 .views(updatedStar.getViews())
+                .faviconUrl(updatedStar.getFavicons().toString())
                 .keywordList(updatedStar.getKeywords().stream()
                         .map(Keyword::getName)
                         .toList())

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -14,7 +14,6 @@ import com.team_nebula.nebula.domain.star.dto.response.GetSearchedStarOneRespons
 import com.team_nebula.nebula.domain.star.dto.response.GetStarListResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
 import com.team_nebula.nebula.domain.star.repository.StarRepository;
-import com.team_nebula.nebula.domain.user.repository.neo4j.UserNodeRepository;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 
@@ -26,7 +25,6 @@ import lombok.RequiredArgsConstructor;
 public class StarQueryServiceImpl implements StarQueryService {
 
     private final StarRepository starRepository;
-    private final UserNodeRepository userNodeRepository;
     private final LinkQueryService linkQueryService;
 
     // 스타 + 링크 전체 조회


### PR DESCRIPTION


## 💡 개요  
프론트엔드 요처응로 Link 노드에 공유된 키워드 리스트(`sharedKeywords`)를 저장하기 위한 기능을 추가
스타 간의 링크 생성, 업데이트, 조회할 경우 sharedKeywords도 조회할 수 있게 기능 수정

## 🔨 작업 사항  
- `Link` 엔티티에 `sharedKeywords` 속성 추가  
- `createLinksBetweenStars` 쿼리 수정 -> 스타 생성, 업데이트할 경우 링크 설정에 사용하는 쿼리
  - `sharedKeywords` 리스트를 `COLLECT(DISTINCT k.name)`으로 수집  
  - `WITH`절에서 키워드 리스트와 개수를 함께 처리  
  - `ON CREATE SET` 시 `sharedKeywords` 저장 로직 추가  

## 📝 기타  
- sharedKeywords가 리스트로 가기 때문에 sharedKeywordNum(공유된 키워드 개수)의 존재가 꼭 필요한지 의문이 든다. 이 부분에 대해서 어떻게 생각하는지 의견 주시면 감사하겠습니다.