### PR TITLE
SCRUM-184: 소셜 로그인 헤더 검증에서 쿠키 자체 검증으로 수정

### DIFF
--- a/src/main/java/com/team_nebula/nebula/global/constants/Constants.java
+++ b/src/main/java/com/team_nebula/nebula/global/constants/Constants.java
@@ -7,14 +7,13 @@ public final class Constants {
 	private Constants() {}
 
 	public static List<String> NO_NEED_FILTER_URLS = List.of(
-		"/oauth2/authorization/kakao",
-		"/oauth2/authorization/google",
 		"/swagger-ui.html/**",
 		"/v3/api-docs/**",
 		"/swagger-ui/**",
 		"/h2-console/**",
 		"/api/v1/oauth/generate",
-		"/api/v1/oauth/{provider}",
+		"/api/v1/oauth/kakao",
+		"/api/v1/oauth/google",
 		"/api/v1/terms",
 		"/api/v1/keywords/top10-used"
 	);

--- a/src/main/java/com/team_nebula/nebula/global/oauth/api/OAuthController.java
+++ b/src/main/java/com/team_nebula/nebula/global/oauth/api/OAuthController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.team_nebula.nebula.global.annotation.AuthUser;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
-import com.team_nebula.nebula.global.oauth.dto.TokenResponseDTO;
 import com.team_nebula.nebula.global.oauth.handler.CustomSuccessHandler;
 import com.team_nebula.nebula.global.oauth.service.CustomOAuth2UserService;
 
@@ -46,6 +45,12 @@ public class OAuthController {
 		@AuthUser Long userId) {
 		customOAuth2UserService.reissue(userId, response);
 		return ApiResponse.onSuccess("토큰 재발급 완료");
+	}
+
+	@PostMapping("/logout")
+	public ApiResponse<?> logout(HttpServletResponse response) {
+		customOAuth2UserService.logout(response);
+		return ApiResponse.onSuccess("로그아웃 완료");
 	}
 
 	/*

--- a/src/main/java/com/team_nebula/nebula/global/oauth/api/OAuthController.java
+++ b/src/main/java/com/team_nebula/nebula/global/oauth/api/OAuthController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.team_nebula.nebula.global.annotation.AuthUser;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
-import com.team_nebula.nebula.global.oauth.handler.CustomSuccessHandler;
 import com.team_nebula.nebula.global.oauth.service.CustomOAuth2UserService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,7 +25,6 @@ import lombok.RequiredArgsConstructor;
 public class OAuthController {
 
 	private final CustomOAuth2UserService customOAuth2UserService;
-	private final CustomSuccessHandler customSuccessHandler;
 
 	@GetMapping("/{provider}")
 	public void redirectOAuth2(

--- a/src/main/java/com/team_nebula/nebula/global/oauth/api/OAuthController.java
+++ b/src/main/java/com/team_nebula/nebula/global/oauth/api/OAuthController.java
@@ -42,10 +42,10 @@ public class OAuthController {
 	}
 
 	@PostMapping("/reissue")
-	public ApiResponse<?> reissue(HttpServletRequest request,
+	public ApiResponse<?> reissue(HttpServletResponse response,
 		@AuthUser Long userId) {
-		TokenResponseDTO dto = customOAuth2UserService.reissue(userId);
-		return ApiResponse.onSuccess(dto);
+		customOAuth2UserService.reissue(userId, response);
+		return ApiResponse.onSuccess("토큰 재발급 완료");
 	}
 
 	/*

--- a/src/main/java/com/team_nebula/nebula/global/oauth/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/team_nebula/nebula/global/oauth/handler/CustomSuccessHandler.java
@@ -1,13 +1,10 @@
 package com.team_nebula.nebula.global.oauth.handler;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -19,10 +16,10 @@ import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import com.team_nebula.nebula.global.oauth.dto.CustomOAuth2User;
 import com.team_nebula.nebula.global.oauth.dto.TokenResponseDTO;
+import com.team_nebula.nebula.global.util.CookieUtil;
 import com.team_nebula.nebula.global.util.JWTUtil;
 
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -50,52 +47,60 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
 
-		CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+		CustomOAuth2User customUserDetails = (CustomOAuth2User)authentication.getPrincipal();
 		String username = customUserDetails.getUsername();
+		User user = findUserByUsername(username);
 
 		TokenResponseDTO tokenResponseDTO = jwtUtil.generateTokens(username);
+		updateRefreshToken(user, tokenResponseDTO.getRefreshToken());
 
-		User user = userRepository.findByUsername(username)
-			.orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
-
-		user.updateRefreshToken(tokenResponseDTO.getRefreshToken());
-		userRepository.save(user);
-
-		long accessTokenExpirationTime = jwtUtil.getExpiration(tokenResponseDTO.getAccessToken()).getTime();
-		long refreshTokenExpirationTime = jwtUtil.getExpiration(tokenResponseDTO.getRefreshToken()).getTime();
-
-		// redirectType web 과 extension 구분
 		HttpSession session = request.getSession(false);
-		String redirectType = (String) session.getAttribute("redirectType");
+		String redirectType = (String)session.getAttribute("redirectType");
+		String redirectUrl = "";
 
-		String redirectUrl = "web".equals(redirectType) ? webRedirectUrl : extensionRedirectUrl;
-
-		if (redirectType.equals("web")) {
-			response.addCookie(createCookie("accessToken", tokenResponseDTO.getAccessToken(), accessTokenExpirationTime));
-			response.addCookie(createCookie("refreshToken", tokenResponseDTO.getRefreshToken(), refreshTokenExpirationTime));
+		if (redirectType.equals("extension")) {
+			redirectUrl = generateExtensionToken(tokenResponseDTO);
 		} else {
-			redirectUrl = String.format("%s?accessToken=%s&refreshToken=%s", redirectUrl,
-				tokenResponseDTO.getAccessToken(), tokenResponseDTO.getRefreshToken());
+			redirectUrl = generateWebToken(response, tokenResponseDTO);
 		}
 
-		// 이용약관 동의 여부 확인
-		List<UserTerm> userTerms = userTermRepository.findByUser(user);
-
-		boolean isAgreed = !userTerms.isEmpty();
-
+		boolean isAgreed = isAgreedTerms(user);
 		redirectUrl = String.format("%s?isAgreed=%s", redirectUrl, isAgreed);
-
 		response.sendRedirect(redirectUrl);
 	}
 
-	private Cookie createCookie(String key, String value, long expirationTime) {
-		Cookie cookie = new Cookie(key, value);
-		cookie.setMaxAge((int)expirationTime);
-		cookie.setSecure(true);
-		cookie.setDomain("nebula-ai.kr");
-		cookie.setPath("/");
-		cookie.setHttpOnly(true);
+	private User findUserByUsername(String username) {
+		return userRepository.findByUsername(username)
+			.orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+	}
 
-		return cookie;
+	private void updateRefreshToken(User user, String refreshToken) {
+		user.updateRefreshToken(refreshToken);
+		userRepository.save(user);
+	}
+
+	private String generateWebToken(HttpServletResponse response, TokenResponseDTO tokenResponseDTO) {
+		long refreshTokenExpirationTime = jwtUtil.getExpiration(tokenResponseDTO.getRefreshToken()).getTime();
+
+		response.addCookie(
+			CookieUtil.createCookie("accessToken", tokenResponseDTO.getAccessToken(), refreshTokenExpirationTime));
+		response.addCookie(
+			CookieUtil.createCookie("refreshToken", tokenResponseDTO.getRefreshToken(), refreshTokenExpirationTime));
+
+		return webRedirectUrl;
+	}
+
+	private String generateExtensionToken(TokenResponseDTO tokenResponseDTO) {
+		String redirectUrl = extensionRedirectUrl;
+
+		redirectUrl = String.format("%s?accessToken=%s&refreshToken=%s", redirectUrl,
+			tokenResponseDTO.getAccessToken(), tokenResponseDTO.getRefreshToken());
+
+		return redirectUrl;
+	}
+
+	private boolean isAgreedTerms(User user) {
+		List<UserTerm> userTerms = userTermRepository.findByUser(user);
+		return !userTerms.isEmpty();
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/global/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/team_nebula/nebula/global/oauth/service/CustomOAuth2UserService.java
@@ -161,4 +161,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 			.refreshToken(refreshToken)
 			.build();
 	}
+
+	public void logout(HttpServletResponse response) {
+		CookieUtil.deleteCookie("accessToken", response);
+		CookieUtil.deleteCookie("refreshToken", response);
+	}
 }

--- a/src/main/java/com/team_nebula/nebula/global/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/team_nebula/nebula/global/oauth/service/CustomOAuth2UserService.java
@@ -119,12 +119,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		}
 	}
 
-	public User loadUserByUsername(String username) {
-
-		return userRepository.findByUsername(username)
-			.orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
-	}
-
 	@Transactional
 	public void reissue(Long userId, HttpServletResponse response) {
 

--- a/src/main/java/com/team_nebula/nebula/global/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/team_nebula/nebula/global/oauth/service/CustomOAuth2UserService.java
@@ -22,7 +22,10 @@ import com.team_nebula.nebula.global.oauth.dto.GoogleResponseDTO;
 import com.team_nebula.nebula.global.oauth.dto.KakaoResponseDTO;
 import com.team_nebula.nebula.global.oauth.dto.OAuth2Response;
 import com.team_nebula.nebula.global.oauth.dto.TokenResponseDTO;
+import com.team_nebula.nebula.global.util.CookieUtil;
 import com.team_nebula.nebula.global.util.JWTUtil;
+
+import jakarta.servlet.http.HttpServletResponse;
 
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
@@ -123,12 +126,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 	}
 
 	@Transactional
-	public TokenResponseDTO reissue(Long userId) {
+	public void reissue(Long userId, HttpServletResponse response) {
 
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-		return jwtUtil.generateTokens(user.getUsername());
+		TokenResponseDTO tokenResponseDTO = jwtUtil.generateTokens(user.getUsername());
+		long expiration = jwtUtil.getExpiration(tokenResponseDTO.getRefreshToken()).getTime();
+
+		response.addCookie(CookieUtil.createCookie("accessToken", tokenResponseDTO.getAccessToken(), expiration));
 	}
 
 	public TokenResponseDTO generate() {

--- a/src/main/java/com/team_nebula/nebula/global/util/CookieUtil.java
+++ b/src/main/java/com/team_nebula/nebula/global/util/CookieUtil.java
@@ -1,0 +1,51 @@
+package com.team_nebula.nebula.global.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CookieUtil {
+
+	public static Cookie createCookie(String name, String value, long expiration) {
+		Cookie cookie = new Cookie(name, value);
+		cookie.setHttpOnly(true);
+		cookie.setPath("/");
+		cookie.setMaxAge((int)getTokenMaxAgeInSeconds(expiration));
+		return cookie;
+	}
+
+	public static long getTokenMaxAgeInSeconds(long expiration) {
+		long now = System.currentTimeMillis();
+		return (expiration - now) / 1000;
+	}
+
+	public static void deleteCookie(String name, HttpServletResponse response) {
+		Cookie cookie = new Cookie(name, null);
+		cookie.setHttpOnly(true);
+		cookie.setPath("/");
+		cookie.setMaxAge(0);
+		response.addCookie(cookie);
+	}
+
+	public static Map<String, String> extractTokensFromCookie(HttpServletRequest request) {
+		Map<String, String> tokens = new HashMap<>();
+
+		Cookie[] cookies = request.getCookies();
+		if (cookies == null)
+			return null;
+
+		for (Cookie cookie : cookies) {
+			if ("accessToken".equals(cookie.getName())) {
+				tokens.put("accessToken", cookie.getValue());
+
+			} else if ("refreshToken".equals(cookie.getName())) {
+				tokens.put("refreshToken", cookie.getValue());
+			}
+		}
+
+		return tokens;
+	}
+}

--- a/src/main/java/com/team_nebula/nebula/global/util/JWTFilter.java
+++ b/src/main/java/com/team_nebula/nebula/global/util/JWTFilter.java
@@ -1,10 +1,14 @@
 package com.team_nebula.nebula.global.util;
 
+import static com.team_nebula.nebula.global.util.CookieUtil.*;
+
 import java.io.IOException;
+import java.util.Map;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.team_nebula.nebula.domain.user.dto.request.UserDTO;
@@ -12,6 +16,7 @@ import com.team_nebula.nebula.domain.user.entity.User;
 import com.team_nebula.nebula.domain.user.repository.mysql.UserRepository;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
+import com.team_nebula.nebula.global.constants.Constants;
 import com.team_nebula.nebula.global.oauth.dto.CustomOAuth2User;
 
 import jakarta.servlet.FilterChain;
@@ -24,9 +29,18 @@ public class JWTFilter extends OncePerRequestFilter {
 	private final JWTUtil jwtUtil;
 	private final UserRepository userRepository;
 
+	private static final AntPathMatcher pathMatcher = new AntPathMatcher();
+
 	public JWTFilter(JWTUtil jwtUtil, UserRepository userRepository) {
 		this.jwtUtil = jwtUtil;
 		this.userRepository = userRepository;
+	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		String uri = request.getRequestURI();
+		return Constants.NO_NEED_FILTER_URLS.stream()
+			.anyMatch(pattern -> pathMatcher.match(pattern, uri));
 	}
 
 	@Override
@@ -34,33 +48,33 @@ public class JWTFilter extends OncePerRequestFilter {
 		FilterChain filterChain) throws
 		ServletException, IOException {
 
-		String authorizationHeader = request.getHeader("Authorization");
+		Map<String, String> tokens = extractTokensFromCookie(request);
 
-		if (!jwtUtil.validateAuthorizationHeader(authorizationHeader)) {
-			filterChain.doFilter(request, response);
+		if (tokens.isEmpty() || tokens.get("refreshToken") == null) {
+			ErrorResponseUtil.sendErrorResponse(response, ErrorStatus._UNAUTHORIZED);
 			return;
 		}
 
-		String token = authorizationHeader.substring(7);
-
-		if (jwtUtil.isExpired(token)) {
-			ErrorResponseUtil.sendErrorResponse(response, ErrorStatus._BAD_REQUEST);
+		if (tokens.get("accessToken") == null) {
+			ErrorResponseUtil.sendErrorResponse(response, ErrorStatus._TOKEN_EXPIRED);
 			return;
 		}
 
-		String tokenType = jwtUtil.getTokenType(token);
-
-		if (request.getRequestURI().equals("/api/v1/oauth/reissue")) {
-			if (!"refresh".equals(tokenType)) {
-				ErrorResponseUtil.sendErrorResponse(response, ErrorStatus._TOKEN_TYPE_ERROR);
+		if (jwtUtil.isExpired(tokens.get("accessToken"))) {
+			if (request.getRequestURI().equals("/api/v1/oauth/reissue")) {
+				authenticateUser(tokens.get("refreshToken"));
+				filterChain.doFilter(request, response);
 				return;
 			}
 
-		} else if (!"access".equals(tokenType)) {
-			ErrorResponseUtil.sendErrorResponse(response, ErrorStatus._TOKEN_TYPE_ERROR);
+			ErrorResponseUtil.sendErrorResponse(response, ErrorStatus._TOKEN_EXPIRED);
 			return;
 		}
+		authenticateUser(tokens.get("accessToken"));
+		filterChain.doFilter(request, response);
+	}
 
+	private void authenticateUser(String token) {
 		String username = jwtUtil.getUsername(token);
 
 		User user = userRepository.findByUsername(username)
@@ -85,7 +99,5 @@ public class JWTFilter extends OncePerRequestFilter {
 
 		//세션에 사용자 등록
 		SecurityContextHolder.getContext().setAuthentication(authToken);
-
-		filterChain.doFilter(request, response);
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/global/util/JWTUtil.java
+++ b/src/main/java/com/team_nebula/nebula/global/util/JWTUtil.java
@@ -51,16 +51,6 @@ public class JWTUtil {
 			.get("role", String.class);
 	}
 
-	public String getTokenType(String token) {
-
-		return Jwts.parser()
-			.verifyWith(secretKey)
-			.build()
-			.parseSignedClaims(token)
-			.getPayload()
-			.get("tokenType", String.class);
-	}
-
 	public Date getExpiration(String token) {
 		return Jwts.parser()
 			.setSigningKey(secretKey)
@@ -90,19 +80,6 @@ public class JWTUtil {
 			.expiration(new Date(System.currentTimeMillis() + expiredMs * 1000))
 			.signWith(secretKey)
 			.compact();
-	}
-
-	public boolean validateAuthorizationHeader(String authorizationHeader) {
-		if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-			return false;
-		}
-
-		String token = extractTokenFromAuthorizationHeader(authorizationHeader);
-		return !isExpired(token); // 토큰 만료 여부 확인
-	}
-
-	public String extractTokenFromAuthorizationHeader(String authorizationHeader) {
-		return authorizationHeader.replace("Bearer ", "").trim();
 	}
 
 	public TokenResponseDTO generateTokens(String username) {


### PR DESCRIPTION
## 💡 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 기존
소셜 로그인 후 `accessToken`과 `refreshToken`을 Header로 통해 검증

### 로그아웃 API 구현
로그아웃 시 httpOnly 쿠키 삭제

## 🔨작업 사항
<!---- 어떤 변경 사항이 있나요?-->

httpOnly 쿠키 를 사용하여 백엔드에서 토큰을 검증하도록 수정

## 📝 기타 (선택)
<!---- 참고 사항이나 리뷰어에게 전달하고 싶은 내용이 있나요?-->
