### PR TITLE
SCRUM-194 : AI기능 RabbitMQ 통신으로 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.0'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/team_nebula/nebula/domain/favicon/repository/FaviconRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/favicon/repository/FaviconRepository.java
@@ -8,7 +8,7 @@ public interface FaviconRepository extends Neo4jRepository<Favicon, String> {
     @Query("""
         MATCH (f:Favicon)
         WHERE f.faviconUrl = $faviconUrl
-        return favicon
+        return f
            \s""")
     Favicon findByFaviconUrl(String faviconUrl);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/favicon/repository/FaviconRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/favicon/repository/FaviconRepository.java
@@ -2,6 +2,13 @@ package com.team_nebula.nebula.domain.favicon.repository;
 
 import com.team_nebula.nebula.domain.favicon.entity.Favicon;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
 
 public interface FaviconRepository extends Neo4jRepository<Favicon, String> {
+    @Query("""
+        MATCH (f:Favicon)
+        WHERE f.faviconUrl = $faviconUrl
+        return favicon
+           \s""")
+    Favicon findByFaviconUrl(String faviconUrl);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarV1Controller.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarV1Controller.java
@@ -58,7 +58,10 @@ public class StarV1Controller {
     // 스타 입력 완료 API(데이터 입력 후 나머지 노드 생성)
     @Operation(summary = "스타 입력 완료", description = "스타의 카테고리, 사용자메모, AI요약, 키워드를 입력하고 스타 정보 입력을 완료하는 API")
     @PatchMapping("/complete/{starId}")
-    public ApiResponse<PutStarResponseDTO> createCompleteStar(@AuthUser Long userId, @PathVariable UUID starId, @RequestBody CreateStarRequestDTO requestDTO){
+    public ApiResponse<PutStarResponseDTO> createCompleteStar(
+            @AuthUser Long userId,
+            @PathVariable UUID starId,
+            @RequestBody CreateStarRequestDTO requestDTO){
         PutStarResponseDTO responseDTO = starCommandService.createCompleteStar(userId, starId, requestDTO);
 
         return ApiResponse.onSuccess(responseDTO);
@@ -85,7 +88,9 @@ public class StarV1Controller {
     // 카테고리별 스타 조회 API
     @Operation(summary = "카테고리별 스타 조회", description = "특정 카테고리에 속한 스타들을 조회하는 API")
     @GetMapping("/categories/{categoryId}")
-    public ApiResponse<GetStarListResponseDTO> getStarListByCategory(@AuthUser Long userId, @PathVariable UUID categoryId){
+    public ApiResponse<GetStarListResponseDTO> getStarListByCategory(
+            @AuthUser Long userId,
+            @PathVariable UUID categoryId){
         GetStarListResponseDTO responseDTO = starQueryService.getStarListInCategory(userId, categoryId);
 
         return ApiResponse.onSuccess(responseDTO);
@@ -94,7 +99,9 @@ public class StarV1Controller {
     // 키워드별 스타 조회 API
     @Operation(summary = "키워드별 스타 조회", description = "특정 키워드가 포함된 스타들을 조회하는 API")
     @GetMapping("/keywords/{keywordId}")
-    public ApiResponse<GetStarListResponseDTO> getStarListByKeyword(@AuthUser Long userId, @PathVariable String keywordId){
+    public ApiResponse<GetStarListResponseDTO> getStarListByKeyword(
+            @AuthUser Long userId,
+            @PathVariable String keywordId){
         System.out.println("KeywordId: " + keywordId);
         GetStarListResponseDTO responseDTO = starQueryService.getStarListInKeyword(userId, keywordId);
 
@@ -104,7 +111,9 @@ public class StarV1Controller {
     // 스타 검색 API
     @Operation(summary = "스타 검색", description = "title(제목)을 기준으로 스타를 검색하는 API")
     @GetMapping("/search")
-    public ApiResponse<GetSearchedStarListResponseDTO> searchStar(@RequestParam String title, @AuthUser Long userId){
+    public ApiResponse<GetSearchedStarListResponseDTO> searchStar(
+            @RequestParam String title,
+            @AuthUser Long userId){
         GetSearchedStarListResponseDTO responseDTO = starQueryService.searchStars(userId, title);
 
         return ApiResponse.onSuccess(responseDTO);
@@ -126,7 +135,9 @@ public class StarV1Controller {
     // 스타 삭제 API
     @Operation(summary = "스타 삭제", description = "스타를 비활성화하는 API/ 완전 삭제가 아닌 Soft Delete하는 것")
     @PatchMapping("/{starId}/deactivate")
-    public ApiResponse<DeleteStarResponseDTO> deleteStar(@AuthUser Long userId, @PathVariable UUID starId){
+    public ApiResponse<DeleteStarResponseDTO> deleteStar(
+            @AuthUser Long userId,
+            @PathVariable UUID starId){
         DeleteStarResponseDTO responseDTO = starCommandService.deleteStar(userId, starId);
 
         return ApiResponse.onSuccess(responseDTO);
@@ -135,7 +146,9 @@ public class StarV1Controller {
     // 스타화 취소 API
     @Operation(summary = "스타화 취소", description = "스타 등록을 취소하는 API / 크롬 익스텐션에서 북마크 추가하기를 누르고 넘어가는 화면에서 저장 말고 취소를 눌렀을때 스타를 완전 삭제하는 기능")
     @DeleteMapping("/{starId}/cancel")
-    public ApiResponse<DeleteStarResponseDTO> cancelStar(@PathVariable UUID starId, @AuthUser Long userId){
+    public ApiResponse<DeleteStarResponseDTO> cancelStar(
+            @PathVariable UUID starId,
+            @AuthUser Long userId){
         DeleteStarResponseDTO responseDTO = starCommandService.cancelStar(starId);
 
         return ApiResponse.onSuccess(responseDTO);

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarV1Controller.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarV1Controller.java
@@ -34,9 +34,9 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "[ 스타 ]")
+@Tag(name = "[ 스타 V1 ]")
 @RequestMapping("/api/v1/stars")
-public class StarController {
+public class StarV1Controller {
 
     private final StarCommandService starCommandService;
     private final StarQueryService starQueryService;

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarV1Controller.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarV1Controller.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
+import com.team_nebula.nebula.domain.star.dto.request.CompleteStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.DeleteStarResponseDTO;
@@ -61,7 +61,7 @@ public class StarV1Controller {
     public ApiResponse<PutStarResponseDTO> createCompleteStar(
             @AuthUser Long userId,
             @PathVariable UUID starId,
-            @RequestBody CreateStarRequestDTO requestDTO){
+            @RequestBody CompleteStarRequestDTO requestDTO){
         PutStarResponseDTO responseDTO = starCommandService.createCompleteStar(userId, starId, requestDTO);
 
         return ApiResponse.onSuccess(responseDTO);

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarV2Controller.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarV2Controller.java
@@ -27,19 +27,23 @@ public class StarV2Controller {
     @Operation(summary = "북마크 추가", description = "크롬 익스텐션에서 처음 북마크를 추가하는 API로 AI 추천 키워드 리스를 반환한다.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResponse<AddBookMarkResponseDTO> addBookMark(
+            @AuthUser Long userId,
             @RequestPart(value = "htmlFile",required = false) MultipartFile htmlFile,
             @RequestParam(value = "title") String title,
             @RequestParam(value = "siteUrl") String siteUrl
     ){
-        AddBookMarkResponseDTO responseDTO = starCommandService.addBookMark(htmlFile, title, siteUrl);
+        AddBookMarkResponseDTO responseDTO = starCommandService.addBookMark(userId, htmlFile, title, siteUrl);
 
         return ApiResponse.onSuccessCreated(responseDTO);
     }
 
-    // 스타 입력 완료 API(데이터 입력 후 나머지 노드 생성)
-    @Operation(summary = "스타 입력 완료", description = "스타의 카테고리, 사용자메모, AI요약, 키워드를 입력하고 스타 정보 입력을 완료하는 API")
+    // 스타 저장 API(데이터 입력 후 나머지 노드 생성)
+    @Operation(summary = "스타 저장", description = "스타의 타이틀, 사이트 url, Tjaspdlf카테고리, 사용자메모, AI요약, 키워드를 입력하고 스타 정보 입력을 완료하는 API")
     @PatchMapping("/complete/{starId}")
-    public ApiResponse<PutStarResponseDTO> createCompleteStar(@AuthUser Long userId, @PathVariable UUID starId, @RequestBody CreateStarRequestDTO requestDTO){
+    public ApiResponse<PutStarResponseDTO> createCompleteStar(
+            @AuthUser Long userId,
+            @PathVariable UUID starId,
+            @RequestBody CreateStarRequestDTO requestDTO){
         PutStarResponseDTO responseDTO = starCommandService.createCompleteStar(userId, starId, requestDTO);
 
         return ApiResponse.onSuccess(responseDTO);

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarV2Controller.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarV2Controller.java
@@ -1,0 +1,47 @@
+package com.team_nebula.nebula.domain.star.api;
+
+import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
+import com.team_nebula.nebula.domain.star.dto.response.AddBookMarkResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.PutStarResponseDTO;
+import com.team_nebula.nebula.domain.star.service.StarCommandService;
+import com.team_nebula.nebula.global.annotation.AuthUser;
+import com.team_nebula.nebula.global.apipayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "[ 스타 V2 ]")
+@RequestMapping("/api/v2/stars")
+public class StarV2Controller {
+
+    private final StarCommandService starCommandService;
+
+    // 북마크 추가 API(크롬 익스텐션에서 처음 북마크를 추가하는 경우)
+    @Operation(summary = "북마크 추가", description = "크롬 익스텐션에서 처음 북마크를 추가하는 API로 AI 추천 키워드 리스를 반환한다.")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<AddBookMarkResponseDTO> addBookMark(
+            @RequestPart(value = "htmlFile",required = false) MultipartFile htmlFile,
+            @RequestParam(value = "title") String title,
+            @RequestParam(value = "siteUrl") String siteUrl
+    ){
+        AddBookMarkResponseDTO responseDTO = starCommandService.addBookMark(htmlFile, title, siteUrl);
+
+        return ApiResponse.onSuccessCreated(responseDTO);
+    }
+
+    // 스타 입력 완료 API(데이터 입력 후 나머지 노드 생성)
+    @Operation(summary = "스타 입력 완료", description = "스타의 카테고리, 사용자메모, AI요약, 키워드를 입력하고 스타 정보 입력을 완료하는 API")
+    @PatchMapping("/complete/{starId}")
+    public ApiResponse<PutStarResponseDTO> createCompleteStar(@AuthUser Long userId, @PathVariable UUID starId, @RequestBody CreateStarRequestDTO requestDTO){
+        PutStarResponseDTO responseDTO = starCommandService.createCompleteStar(userId, starId, requestDTO);
+
+        return ApiResponse.onSuccess(responseDTO);
+    }
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarV2Controller.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarV2Controller.java
@@ -1,7 +1,9 @@
 package com.team_nebula.nebula.domain.star.api;
 
+import com.team_nebula.nebula.domain.star.dto.request.CompleteStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.AddBookMarkResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
 import com.team_nebula.nebula.domain.star.dto.response.PutStarResponseDTO;
 import com.team_nebula.nebula.domain.star.service.StarCommandService;
 import com.team_nebula.nebula.global.annotation.AuthUser;
@@ -34,18 +36,17 @@ public class StarV2Controller {
     ){
         AddBookMarkResponseDTO responseDTO = starCommandService.addBookMark(userId, htmlFile, title, siteUrl);
 
-        return ApiResponse.onSuccessCreated(responseDTO);
+        return ApiResponse.onSuccess(responseDTO);
     }
 
     // 스타 저장 API(데이터 입력 후 나머지 노드 생성)
-    @Operation(summary = "스타 저장", description = "스타의 타이틀, 사이트 url, Tjaspdlf카테고리, 사용자메모, AI요약, 키워드를 입력하고 스타 정보 입력을 완료하는 API")
-    @PatchMapping("/complete/{starId}")
-    public ApiResponse<PutStarResponseDTO> createCompleteStar(
+    @Operation(summary = "스타 저장", description = "스타의 타이틀, 사이트 url, 썸네일url, 파비콘url, 카테고리, 사용자메모, AI요약, 키워드를 입력하고 스타 정보 입력을 완료하는 API")
+    @PostMapping("/save")
+    public ApiResponse<CreateStarResponseDTO> createStar(
             @AuthUser Long userId,
-            @PathVariable UUID starId,
             @RequestBody CreateStarRequestDTO requestDTO){
-        PutStarResponseDTO responseDTO = starCommandService.createCompleteStar(userId, starId, requestDTO);
+        CreateStarResponseDTO responseDTO = starCommandService.createStar(userId, requestDTO);
 
-        return ApiResponse.onSuccess(responseDTO);
+        return ApiResponse.onSuccessCreated(responseDTO);
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/AnalyzeHtmlRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/AnalyzeHtmlRequestDTO.java
@@ -1,0 +1,12 @@
+package com.team_nebula.nebula.domain.star.dto.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnalyzeHtmlRequestDTO {
+    private String htmlFileKey;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/AnalyzeHtmlRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/AnalyzeHtmlRequestDTO.java
@@ -9,5 +9,5 @@ import lombok.*;
 @Builder
 public class AnalyzeHtmlRequestDTO {
     private Long userId;
-    private String htmlFileKey;
+    private String s3Key;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/AnalyzeHtmlRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/AnalyzeHtmlRequestDTO.java
@@ -8,5 +8,6 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class AnalyzeHtmlRequestDTO {
+    private Long userId;
     private String htmlFileKey;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CompleteStarRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CompleteStarRequestDTO.java
@@ -11,10 +11,8 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateStarRequestDTO {
-    private String title;
-    private String siteUrl;
-    private String faviconUrl;
+public class CompleteStarRequestDTO {
+
     private String thumbnailUrl;
     private String summaryAI;
     private String userMemo;

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/AddBookMarkResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/AddBookMarkResponseDTO.java
@@ -1,0 +1,20 @@
+package com.team_nebula.nebula.domain.star.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AddBookMarkResponseDTO {
+    private String title;
+    private String siteUrl;
+    private String thumbnailUrl;
+    private String faviconUrl;
+    private List<String> keywords;
+}

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/CreateStarResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/CreateStarResponseDTO.java
@@ -19,5 +19,5 @@ public class CreateStarResponseDTO {
     private String siteUrl;
     private String thumbnailUrl;
     private String faviconUrl;
-    private List<String> keywords;
+    private List<String> keywordList;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -2,10 +2,7 @@ package com.team_nebula.nebula.domain.star.service;
 
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
-import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
-import com.team_nebula.nebula.domain.star.dto.response.DeleteStarResponseDTO;
-import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
-import com.team_nebula.nebula.domain.star.dto.response.PutStarResponseDTO;
+import com.team_nebula.nebula.domain.star.dto.response.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
@@ -21,4 +18,6 @@ public interface StarCommandService {
     public DeleteStarResponseDTO deleteStar(Long userId, UUID starId);
 
     public DeleteStarResponseDTO cancelStar(UUID starId);
+
+    public AddBookMarkResponseDTO addBookMark(MultipartFile htmlFile, String title, String siteUrl);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -19,5 +19,5 @@ public interface StarCommandService {
 
     public DeleteStarResponseDTO cancelStar(UUID starId);
 
-    public AddBookMarkResponseDTO addBookMark(MultipartFile htmlFile, String title, String siteUrl);
+    public AddBookMarkResponseDTO addBookMark(Long userId, MultipartFile htmlFile, String title, String siteUrl);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -1,5 +1,6 @@
 package com.team_nebula.nebula.domain.star.service;
 
+import com.team_nebula.nebula.domain.star.dto.request.CompleteStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.*;
@@ -11,7 +12,7 @@ public interface StarCommandService {
 
     public CreateStarResponseDTO createFirstStar(Long userId, MultipartFile htmlFile, String title, String siteUrl);
 
-    public PutStarResponseDTO createCompleteStar(Long userId, UUID starId, CreateStarRequestDTO requestDTO);
+    public PutStarResponseDTO createCompleteStar(Long userId, UUID starId, CompleteStarRequestDTO requestDTO);
 
     public GetStarOneResponseDTO updateStar(Long userId, UUID starId, UpdateStarOneRequestDTO requestDTO);
 
@@ -20,4 +21,6 @@ public interface StarCommandService {
     public DeleteStarResponseDTO cancelStar(UUID starId);
 
     public AddBookMarkResponseDTO addBookMark(Long userId, MultipartFile htmlFile, String title, String siteUrl);
+
+    public CreateStarResponseDTO createStar(Long userId, CreateStarRequestDTO requestDTO);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -2,7 +2,9 @@ package com.team_nebula.nebula.domain.star.service;
 
 import com.team_nebula.nebula.domain.favicon.entity.Favicon;
 import com.team_nebula.nebula.domain.favicon.service.FaviconService;
+import com.team_nebula.nebula.domain.star.dto.response.*;
 import com.team_nebula.nebula.global.AI.dto.GetThumbnailAndKeywordsResponseDTO;
+import com.team_nebula.nebula.global.AI.service.AiMessageService;
 import com.team_nebula.nebula.global.AI.service.AiService;
 import com.team_nebula.nebula.domain.category.service.CategoryCommandService;
 import com.team_nebula.nebula.domain.category.service.CategoryQueryService;
@@ -12,10 +14,6 @@ import com.team_nebula.nebula.domain.keyword.service.KeywordCommandService;
 import com.team_nebula.nebula.domain.link.service.LinkCommandService;
 import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
-import com.team_nebula.nebula.domain.star.dto.response.CreateStarResponseDTO;
-import com.team_nebula.nebula.domain.star.dto.response.DeleteStarResponseDTO;
-import com.team_nebula.nebula.domain.star.dto.response.GetStarOneResponseDTO;
-import com.team_nebula.nebula.domain.star.dto.response.PutStarResponseDTO;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.domain.star.repository.StarRepository;
 import com.team_nebula.nebula.domain.user.entity.UserNode;
@@ -45,6 +43,7 @@ public class StarCommandServiceImpl implements StarCommandService {
     private final FaviconService faviconService;
     private final S3Service s3Service;
     private final AiService aiService;
+    private final AiMessageService aiMessageService;
 
     @Override
     public CreateStarResponseDTO createFirstStar(Long userId, MultipartFile htmlFile, String title, String siteUrl){
@@ -209,5 +208,23 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .deleteStatus(canceledMessage)
                 .build();
     }
+
+    @Override
+    public AddBookMarkResponseDTO addBookMark(MultipartFile htmlFile, String title, String siteUrl){
+        String htmlFileKey = s3Service.saveHtmlFile(htmlFile, title);
+
+        Favicon favicon = faviconService.getOrCreateFavicon(siteUrl);
+
+        GetThumbnailAndKeywordsResponseDTO responseDTO = aiMessageService.analyzeHtmlFile(htmlFileKey);
+
+        return AddBookMarkResponseDTO.builder()
+                .title(title)
+                .siteUrl(siteUrl)
+                .faviconUrl(favicon.getFaviconUrl())
+                .thumbnailUrl(responseDTO.getImage_url())
+                .keywords(responseDTO.getKeywords())
+                .build();
+    }
+
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -161,7 +161,7 @@ public class StarCommandServiceImpl implements StarCommandService {
         Star updatedStar = starRepository.save(latestStar);
 
         // 유저 스타 작업 횟수 증가
-        aiService.checkUpdatedCnt(userId);
+//        aiService.checkUpdatedCnt(userId);
 
         return GetStarOneResponseDTO.builder()
                 .starId(updatedStar.getId())
@@ -280,7 +280,7 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .siteUrl(lastStar.getSiteUrl())
                 .thumbnailUrl(lastStar.getThumbnailUrl())
                 .faviconUrl(favicon.getFaviconUrl())
-                .keywordList(updatedStar.getKeywords().stream()
+                .keywordList(lastStar.getKeywords().stream()
                         .map(Keyword::getName)
                         .toList())
                 .build();

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -1,7 +1,9 @@
 package com.team_nebula.nebula.domain.star.service;
 
 import com.team_nebula.nebula.domain.favicon.entity.Favicon;
+import com.team_nebula.nebula.domain.favicon.repository.FaviconRepository;
 import com.team_nebula.nebula.domain.favicon.service.FaviconService;
+import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.*;
 import com.team_nebula.nebula.global.AI.dto.GetThumbnailAndKeywordsResponseDTO;
 import com.team_nebula.nebula.global.AI.service.AiMessageService;
@@ -12,7 +14,7 @@ import com.team_nebula.nebula.global.image.S3Service;
 import com.team_nebula.nebula.domain.keyword.entity.Keyword;
 import com.team_nebula.nebula.domain.keyword.service.KeywordCommandService;
 import com.team_nebula.nebula.domain.link.service.LinkCommandService;
-import com.team_nebula.nebula.domain.star.dto.request.CreateStarRequestDTO;
+import com.team_nebula.nebula.domain.star.dto.request.CompleteStarRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.domain.star.repository.StarRepository;
@@ -44,6 +46,7 @@ public class StarCommandServiceImpl implements StarCommandService {
     private final S3Service s3Service;
     private final AiService aiService;
     private final AiMessageService aiMessageService;
+    private final FaviconRepository faviconRepository;
 
     @Override
     public CreateStarResponseDTO createFirstStar(Long userId, MultipartFile htmlFile, String title, String siteUrl){
@@ -86,7 +89,7 @@ public class StarCommandServiceImpl implements StarCommandService {
                     .siteUrl(savedStar.getSiteUrl())
                     .thumbnailUrl(responseDTO.getImage_url())
                     .faviconUrl(favicon.getFaviconUrl())
-                    .keywords(responseDTO.getKeywords())
+                    .keywordList(responseDTO.getKeywords())
                     .build();
         } catch (Exception e) {
             starRepository.delete(savedStar);
@@ -97,7 +100,7 @@ public class StarCommandServiceImpl implements StarCommandService {
 
 
     @Override
-    public PutStarResponseDTO createCompleteStar(Long userId, UUID starId, CreateStarRequestDTO requestDTO){
+    public PutStarResponseDTO createCompleteStar(Long userId, UUID starId, CompleteStarRequestDTO requestDTO){
 
         Star star = starRepository.findById(starId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
@@ -223,6 +226,63 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .faviconUrl(favicon.getFaviconUrl())
                 .thumbnailUrl(responseDTO.getImage_url())
                 .keywords(responseDTO.getKeywords())
+                .build();
+    }
+
+    @Override
+    public CreateStarResponseDTO createStar(Long userId, CreateStarRequestDTO requestDTO){
+        // 유저 찾기
+        UserNode userNode = userNodeRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        // 스타 노드 생성
+        Star star = Star.builder()
+                .title(requestDTO.getTitle())
+                .siteUrl(requestDTO.getSiteUrl())
+                .thumbnailUrl(requestDTO.getThumbnailUrl())
+                .summaryAI(requestDTO.getSummaryAI())
+                .userMemo(requestDTO.getUserMemo())
+                .build();
+
+        Star savedStar = starRepository.save(star);
+        if (savedStar.getId() == null) {
+            throw new GeneralException(ErrorStatus._STAR_CREATION_FAILED);
+        }
+
+        // 유저-스타 관계 설정
+        userNode.getStars().add(savedStar);
+        userNodeRepository.save(userNode);
+
+        // 카테고리 생성 및 유저-카테고리 관게설정
+        categoryCommandService.linkStarToCategory(star, requestDTO.getCategoryName());
+
+        // 스타-파비콘 관계 설정
+        Favicon favicon = faviconRepository.findByFaviconUrl(requestDTO.getFaviconUrl());
+        savedStar.getFavicons().add(favicon);
+        Star updatedStar = starRepository.save(savedStar);
+
+        // 키워드 노드 생성 및 스타-키워드 관계설정
+        keywordCommandService.linkStarToKeywords(updatedStar, requestDTO.getKeywordList());
+
+        // 스타간 링크 노드 생성 및 관계설정
+        Star lastStar = starRepository.findById(updatedStar.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._STAR_NOT_FOUND));
+        linkCommandService.createLinksForStar(userId, lastStar);
+
+        starRepository.save(lastStar);
+
+        // 유저 스타 작업 횟수 증가
+//        aiService.checkUpdatedCnt(userId);
+
+        return CreateStarResponseDTO.builder()
+                .starId(lastStar.getId())
+                .title(lastStar.getTitle())
+                .siteUrl(lastStar.getSiteUrl())
+                .thumbnailUrl(lastStar.getThumbnailUrl())
+                .faviconUrl(favicon.getFaviconUrl())
+                .keywordList(updatedStar.getKeywords().stream()
+                        .map(Keyword::getName)
+                        .toList())
                 .build();
     }
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -210,12 +210,12 @@ public class StarCommandServiceImpl implements StarCommandService {
     }
 
     @Override
-    public AddBookMarkResponseDTO addBookMark(MultipartFile htmlFile, String title, String siteUrl){
+    public AddBookMarkResponseDTO addBookMark(Long userId, MultipartFile htmlFile, String title, String siteUrl){
         String htmlFileKey = s3Service.saveHtmlFile(htmlFile, title);
 
         Favicon favicon = faviconService.getOrCreateFavicon(siteUrl);
 
-        GetThumbnailAndKeywordsResponseDTO responseDTO = aiMessageService.analyzeHtmlFile(htmlFileKey);
+        GetThumbnailAndKeywordsResponseDTO responseDTO = aiMessageService.analyzeHtmlFile(userId, htmlFileKey);
 
         return AddBookMarkResponseDTO.builder()
                 .title(title)

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
@@ -21,11 +21,8 @@ public class AiMessageService {
     private final RabbitTemplate rabbitTemplate;
     private final ObjectMapper objectMapper;
 
-    @Value("${rabbitmq.queues.extractData}")
+    @Value("${rabbitmq.queue.extract-data}")
     private String extractDataQueue;
-
-    @Value("${rabbitmq.queues.extractDataResponse}")
-    private String extractDataResponseQueue;
 
     public GetThumbnailAndKeywordsResponseDTO analyzeHtmlFile(Long userId, String htmlFileKey) {
         try {

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
@@ -21,8 +21,9 @@ public class AiMessageService {
     @Value("${rabbitmq.routing.key}")
     private String routingKey;
 
-    public GetThumbnailAndKeywordsResponseDTO analyzeHtmlFile(String htmlFileKey) {
+    public GetThumbnailAndKeywordsResponseDTO analyzeHtmlFile(Long userId, String htmlFileKey) {
         AnalyzeHtmlRequestDTO request = AnalyzeHtmlRequestDTO.builder()
+                .userId(userId)
                 .htmlFileKey(htmlFileKey)
                 .build();
 

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
@@ -1,0 +1,47 @@
+package com.team_nebula.nebula.global.AI.service;
+
+import com.team_nebula.nebula.domain.star.dto.request.AnalyzeHtmlRequestDTO;
+import com.team_nebula.nebula.global.AI.dto.GetThumbnailAndKeywordsResponseDTO;
+import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
+import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AiMessageService {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    @Value("${rabbitmq.exchange.name}")
+    private String exchange;
+
+    @Value("${rabbitmq.routing.key}")
+    private String routingKey;
+
+    public GetThumbnailAndKeywordsResponseDTO analyzeHtmlFile(String htmlFileKey) {
+        AnalyzeHtmlRequestDTO request = AnalyzeHtmlRequestDTO.builder()
+                .htmlFileKey(htmlFileKey)
+                .build();
+
+        try {
+            // AI 서버로 메시지 전송하고 응답 대기 (RPC 방식)
+            GetThumbnailAndKeywordsResponseDTO response = (GetThumbnailAndKeywordsResponseDTO) rabbitTemplate.convertSendAndReceive(
+                    exchange,
+                    routingKey,
+                    request
+            );
+
+            if (response == null) {
+                throw new GeneralException(ErrorStatus._AI_EXTRACT_DATA_ERROR);
+            }
+            return response;
+
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus._AI_EXTRACT_DATA_ERROR);
+        }
+    }
+}
+

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
@@ -1,44 +1,53 @@
 package com.team_nebula.nebula.global.AI.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team_nebula.nebula.domain.star.dto.request.AnalyzeHtmlRequestDTO;
 import com.team_nebula.nebula.global.AI.dto.GetThumbnailAndKeywordsResponseDTO;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class AiMessageService {
 
     private final RabbitTemplate rabbitTemplate;
+    private final ObjectMapper objectMapper;
 
-    @Value("${rabbitmq.exchange.name}")
-    private String exchange;
+    @Value("${rabbitmq.queues.extractData}")
+    private String extractDataQueue;
 
-    @Value("${rabbitmq.routing.key}")
-    private String routingKey;
+    @Value("${rabbitmq.queues.extractDataResponse}")
+    private String extractDataResponseQueue;
 
     public GetThumbnailAndKeywordsResponseDTO analyzeHtmlFile(Long userId, String htmlFileKey) {
-        AnalyzeHtmlRequestDTO request = AnalyzeHtmlRequestDTO.builder()
-                .userId(userId)
-                .htmlFileKey(htmlFileKey)
-                .build();
-
         try {
-            // AI 서버로 메시지 전송하고 응답 대기 (RPC 방식)
-            GetThumbnailAndKeywordsResponseDTO response = (GetThumbnailAndKeywordsResponseDTO) rabbitTemplate.convertSendAndReceive(
-                    exchange,
-                    routingKey,
-                    request
-            );
+            // 1. 요청 메시지 생성
+            Map<String, Object> message = new HashMap<>();
+            message.put("s3_key", htmlFileKey);
+            message.put("user_id", userId);
+
+            // 2. JSON 문자열로 변환
+            String jsonMessage = objectMapper.writeValueAsString(message);
+
+            // 3. 메시지 전송 및 응답 대기 (5초 제한)
+            Message response = rabbitTemplate.sendAndReceive(extractDataQueue, new Message(jsonMessage.getBytes()));
 
             if (response == null) {
                 throw new GeneralException(ErrorStatus._AI_EXTRACT_DATA_ERROR);
             }
-            return response;
+
+            String responseJson = new String(response.getBody());
+
+            // 4. 응답 JSON을 DTO로 변환
+            return objectMapper.readValue(responseJson, GetThumbnailAndKeywordsResponseDTO.class);
 
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus._AI_EXTRACT_DATA_ERROR);

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiService.java
@@ -7,7 +7,6 @@ import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.scheduling.annotation.Async;

--- a/src/main/java/com/team_nebula/nebula/global/config/WebMVCConfig.java
+++ b/src/main/java/com/team_nebula/nebula/global/config/WebMVCConfig.java
@@ -29,7 +29,7 @@ public class WebMVCConfig implements WebMvcConfigurer {
 	@Override
 	public void addInterceptors(final InterceptorRegistry registry) {
 		registry.addInterceptor(new JWTInterceptor())
-			.addPathPatterns("/api/v1/**")
+			.addPathPatterns("/api/**")
 			.excludePathPatterns(Constants.NO_NEED_FILTER_URLS);
 	}
 }


### PR DESCRIPTION
## 💡 개요
- 북마크 추가, 스타 저장 기능 수정
- v2Controller 구현

## 🔨작업 사항
### 1. v2Controlelr 구현
- 현재 북마크 추가, 스타 저장 기능만 v2로 구현함

### 2. 북마크 추가 기능 수정
![image](https://github.com/user-attachments/assets/f4eeaaf6-eadd-4e31-b885-7dc88206fd84)
- 기존 플로우는 스타 저장 + 메타데이터 입력에서 북마크 추가+스타 저장으로 수정됨
- 북마크 추가는 스타 노드를 생성하지 않고 AI 서버에서 추천 키워드 리스트와 썸네일 이미지를 받고 프론트에 넘겨줌

### 3. 스타 저장 기능 수정
- 이제 사용자가 내용을 입력 완료 후에 스타 노드가 생성될 수 있음

### 4. AiMessageService 구현
- 기존 AI 서버 통신은 FAST API로 통신했지만 통신의 안전성과 가용성을 보장하기 위해 RabbiMQ로 교체함

