### PR TITLE
SCRUM-202 : 방문기록 전체 조회시 pagiNation 구현

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/history/api/HistoryController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/history/api/HistoryController.java
@@ -2,6 +2,8 @@ package com.team_nebula.nebula.domain.history.api;
 
 import java.util.List;
 
+import com.team_nebula.nebula.domain.history.dto.response.GetHistoryListPageResponseDTO;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "[ 방문기록 ]")
 @RequestMapping("/api/v1/histories")
 public class HistoryController {
 
@@ -42,7 +45,7 @@ public class HistoryController {
 	// 방문기록 전체 조회 API
 	@Operation(summary = "방문기록 전체 조회", description = "사용자의 모든 방문기록 조회하는 API")
 	@GetMapping
-	public ApiResponse<List<GetHistoryListResponseDTO>> getHistories(
+	public ApiResponse<GetHistoryListPageResponseDTO> getHistories(
 		@AuthUser Long userId,
 		@RequestParam(name = "page", defaultValue = "0") int page,
 		@RequestParam(name = "size", defaultValue = "7") int size) {

--- a/src/main/java/com/team_nebula/nebula/domain/history/dto/response/GetHistoryListPageResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/history/dto/response/GetHistoryListPageResponseDTO.java
@@ -1,0 +1,19 @@
+package com.team_nebula.nebula.domain.history.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetHistoryListPageResponseDTO {
+    private int maxPage;
+    private boolean hasNext;
+    private List<GetHistoryListResponseDTO> content;
+
+}

--- a/src/main/java/com/team_nebula/nebula/domain/history/service/HistoryQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/history/service/HistoryQueryService.java
@@ -2,10 +2,11 @@ package com.team_nebula.nebula.domain.history.service;
 
 import java.util.List;
 
+import com.team_nebula.nebula.domain.history.dto.response.GetHistoryListPageResponseDTO;
 import org.springframework.data.domain.Pageable;
 
 import com.team_nebula.nebula.domain.history.dto.response.GetHistoryListResponseDTO;
 
 public interface HistoryQueryService {
-	List<GetHistoryListResponseDTO> getHistories(Long userId, Pageable pageable);
+	GetHistoryListPageResponseDTO getHistories(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/history/service/HistoryQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/history/service/HistoryQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.team_nebula.nebula.domain.history.service;
 import java.util.List;
 import java.util.Set;
 
+import com.team_nebula.nebula.domain.history.dto.response.GetHistoryListPageResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -28,7 +29,7 @@ public class HistoryQueryServiceImpl implements HistoryQueryService {
 	private final StarQueryService starQueryService;
 
 	@Override
-	public List<GetHistoryListResponseDTO> getHistories(Long userId, Pageable pageable) {
+	public GetHistoryListPageResponseDTO getHistories(Long userId, Pageable pageable) {
 		User user = userQueryService.getUserEntity(userId);
 		Page<History> historyPage = historyRepository.findAllByUser(user, pageable);
 		List<History> historyList = historyPage.getContent();
@@ -39,8 +40,24 @@ public class HistoryQueryServiceImpl implements HistoryQueryService {
 
 		Set<String> starUrls = starQueryService.getStarUrls(urls, userId);
 
-		return historyList.stream()
-			.map(history -> HistoryConverter.convertToHistoryListDto(history, starUrls))
-			.toList();
+		List<GetHistoryListResponseDTO> dtoList = historyList.stream()
+				.map(history -> HistoryConverter.convertToHistoryListDto(history, starUrls))
+				.toList();
+
+		int maxPage;
+		if (historyPage.getTotalPages() > 0) {
+			maxPage = historyPage.getTotalPages() - 1;
+		} else {
+			maxPage = 0;
+		}
+
+		boolean hasNext = historyPage.hasNext();
+
+
+		return GetHistoryListPageResponseDTO.builder()
+				.maxPage(maxPage)
+				.hasNext(hasNext)
+				.content(dtoList)
+				.build();
 	}
 }


### PR DESCRIPTION
## 💡 개요
방문기록 전체 조회시 pagiNation 구현

## 🔨작업 사항
```
@Getter
@Builder
@AllArgsConstructor
@NoArgsConstructor
public class GetHistoryListPageResponseDTO {
    private int maxPage;
    private boolean hasNext;
    private List<GetHistoryListResponseDTO> content;

}
```
- maxPage : 최대 페이지 수, hasNext : 다음 페이지 여부를 추가적으로 프론트에 넘겨줌




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 방문 기록 목록 조회 시 페이지네이션 정보(최대 페이지, 다음 페이지 여부, 현재 페이지 데이터)를 포함한 응답으로 개선되었습니다.

- **버그 수정**
    - 방문 기록 목록 API의 응답 구조가 일관성 있게 페이지네이션 정보를 포함하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->