### PR TITLE
SCRUM-205 : 방문기록 최신 정렬 조회로 수정

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/history/api/HistoryController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/history/api/HistoryController.java
@@ -6,6 +6,7 @@ import com.team_nebula.nebula.domain.history.dto.response.GetHistoryListPageResp
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -49,7 +50,7 @@ public class HistoryController {
 		@AuthUser Long userId,
 		@RequestParam(name = "page", defaultValue = "0") int page,
 		@RequestParam(name = "size", defaultValue = "7") int size) {
-		Pageable pageable = PageRequest.of(page, size);
+		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "lastVisitTime"));
 		return ApiResponse.onSuccess(historyQueryService.getHistories(userId, pageable));
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/history/entity/History.java
+++ b/src/main/java/com/team_nebula/nebula/domain/history/entity/History.java
@@ -29,7 +29,7 @@ public class History extends BaseEntity {
 	@Column(name = "last_visit_time", nullable = false)
 	private Double lastVisitTime;
 
-	@Column(name = "titlte", nullable = false)
+	@Column(name = "title", nullable = false)
 	private String title;
 
 	@Column(name = "typed_count", nullable = false)


### PR DESCRIPTION
## 💡 개요
방문기록 최신 정렬 조회로 수정

## 🔨작업 사항
```
// 방문기록 전체 조회 API
	@Operation(summary = "방문기록 전체 조회", description = "사용자의 모든 방문기록 조회하는 API")
	@GetMapping
	public ApiResponse<GetHistoryListPageResponseDTO> getHistories(
		@AuthUser Long userId,
		@RequestParam(name = "page", defaultValue = "0") int page,
		@RequestParam(name = "size", defaultValue = "7") int size) {
		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "lastVisitTime"));
		return ApiResponse.onSuccess(historyQueryService.getHistories(userId, pageable));
	}
```
- lastVisitTime이 가장 최신(내림차순)인 방문기록부터 조회하도록 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 방문 기록 목록이 최근 방문 시간 순으로 정렬되어 표시됩니다.
  - 방문 기록의 제목 컬럼명 오타가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->