### PR TITLE
SCRUM 208 : 스타 저장 후 AI 서버로 데이터전송 기능 추가

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/keyword/api/KeywordController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/api/KeywordController.java
@@ -41,8 +41,8 @@ public class KeywordController {
     }
 
     // 가장 많이 사용된 키워드 10개 조회 API
-    @Operation(summary = "사용순 상위 키워드 10개 조회", description = "가장 많이 사용되고 있는 상위 10개 키워드 이름리스트를 반환한다. 추가로 순위와 키워드가 사용된 횟수를 볼 수 있다.")
-    @GetMapping("/top10-used")
+    @Operation(summary = "사용순 상위 키워드 30개 조회", description = "가장 많이 사용되고 있는 상위 30개 키워드 이름리스트를 반환한다. 추가로 순위와 키워드가 사용된 횟수를 볼 수 있다.")
+    @GetMapping("/trending")
     public ApiResponse<GetMostUsedKeywordListResponseDTO> getKeywords() {
         GetMostUsedKeywordListResponseDTO mostUsedKeywordList = keywordQueryService.getMostUsedKeywordList();
         return ApiResponse.onSuccess(mostUsedKeywordList);

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -46,7 +46,7 @@ public interface KeywordRepository extends Neo4jRepository<Keyword, String> {
     WHERE (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
     RETURN k.name AS keywordName, COUNT(s) AS usedCnt
     ORDER BY usedCnt DESC, keywordName ASC
-    LIMIT 10
+    LIMIT 30
     """)
     List<GetMostUsedKeywordOneResponseDTO> getMostUsedKeywordList();
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
@@ -20,6 +20,7 @@ public class CreateStarRequestDTO {
     private String userMemo;
     private String categoryName;
     private List<String> keywordList;
+    private String s3key;
 
     public String getSummaryAI() {
         if (summaryAI == null || summaryAI.isBlank()) {

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/AddBookMarkResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/AddBookMarkResponseDTO.java
@@ -17,4 +17,5 @@ public class AddBookMarkResponseDTO {
     private String thumbnailUrl;
     private String faviconUrl;
     private List<String> keywords;
+    private String s3key;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -274,6 +274,7 @@ public class StarCommandServiceImpl implements StarCommandService {
 
         // 유저 스타 작업 횟수 증가
 //        aiService.checkUpdatedCnt(userId);
+        aiMessageService.sendStarData(userId, lastStar, requestDTO.getS3key(), lastStar.getUserMemo(), lastStar.getSummaryAI(), requestDTO.getKeywordList());
 
         return CreateStarResponseDTO.builder()
                 .starId(lastStar.getId())

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -226,6 +226,7 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .faviconUrl(favicon.getFaviconUrl())
                 .thumbnailUrl(responseDTO.getImage_url())
                 .keywords(responseDTO.getKeywords())
+                .s3key(htmlFileKey)
                 .build();
     }
 

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
@@ -1,7 +1,7 @@
 package com.team_nebula.nebula.global.AI.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.team_nebula.nebula.domain.star.dto.request.AnalyzeHtmlRequestDTO;
+import com.team_nebula.nebula.domain.star.entity.Star;
 import com.team_nebula.nebula.global.AI.dto.GetThumbnailAndKeywordsResponseDTO;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -23,6 +24,9 @@ public class AiMessageService {
 
     @Value("${rabbitmq.queue.extract-data}")
     private String extractDataQueue;
+
+    @Value("${rabbitmq.queue.save-data}")
+    private String saveDataQueue;
 
     public GetThumbnailAndKeywordsResponseDTO analyzeHtmlFile(Long userId, String htmlFileKey) {
         try {
@@ -48,6 +52,24 @@ public class AiMessageService {
 
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus._AI_EXTRACT_DATA_ERROR);
+        }
+    }
+
+    public void sendStarData(Long userId, Star star, String s3key, String userMemo, String summaryAI, List<String> keywordList){
+        try {
+            Map<String, Object> message = new HashMap<>();
+            message.put("userId", userId);
+            message.put("starId", star.getId().toString());
+            message.put("s3Key", s3key);
+            message.put("memo", userMemo);
+            message.put("summary", summaryAI);
+            message.put("keywords", keywordList);
+
+            String jsonMessage = objectMapper.writeValueAsString(message);
+
+            rabbitTemplate.convertAndSend(saveDataQueue, jsonMessage);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus._AI_STAR_DATA_SEND_ERROR);
         }
     }
 }

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -35,6 +35,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	_AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5000","AI 서버에서 문제가 발생했습니다."),
 	_AI_EXTRACT_DATA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5001","AI에서 썸네일과 추천 키워드을 가져오지 못했습니다."),
 	_AI_KEYWORD_SYNC_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5002","AI Keyword sync 호출에 실해하였습니다."),
+	_AI_STAR_DATA_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5003","AI서버로 데이터 전송이 실해하였습니다."),
 
 	_S3_HTML_FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S35001", "S3에 저장된 html 파일을 삭제하는데 실패했습니다."),
 

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -33,9 +33,9 @@ public enum ErrorStatus implements BaseErrorCode {
 	_MULTIPARTFILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,"MULTIPARTFILE5000","MultipartFile -> File로 변환이 실패하였습니다."),
 
 	_AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5000","AI 서버에서 문제가 발생했습니다."),
-	_AI_EXTRACT_DATA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5001","AI에서 썸네일과 추천 키워드을 가져오지 못했습니다."),
+	_AI_EXTRACT_DATA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5001","AI 에서 썸네일과 추천 키워드을 가져오지 못했습니다."),
 	_AI_KEYWORD_SYNC_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5002","AI Keyword sync 호출에 실해하였습니다."),
-	_AI_STAR_DATA_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5003","AI서버로 데이터 전송이 실해하였습니다."),
+	_AI_STAR_DATA_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5003","AI 서버로 데이터 전송이 실패하였습니다."),
 
 	_S3_HTML_FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S35001", "S3에 저장된 html 파일을 삭제하는데 실패했습니다."),
 


### PR DESCRIPTION
## 💡 개요
스타 저장 후 AI 서버로 데이터전송 기능 추가

## 🔨작업 사항
```
public void sendStarData(Long userId, Star star, String s3key, String userMemo, String summaryAI, List<String> keywordList){
        try {
            Map<String, Object> message = new HashMap<>();
            message.put("userId", userId);
            message.put("starId", star.getId().toString());
            message.put("s3Key", s3key);
            message.put("memo", userMemo);
            message.put("summary", summaryAI);
            message.put("keywords", keywordList);

            String jsonMessage = objectMapper.writeValueAsString(message);

            rabbitTemplate.convertAndSend(saveDataQueue, jsonMessage);
        } catch (Exception e) {
            throw new GeneralException(ErrorStatus._AI_STAR_DATA_SEND_ERROR);
        }
    }
```
- 스타 저장 서비스 작업이 다 마무리된 후에 AI 서버에 유저id, 스타id, s3key, userMemo, summaryAI, keywordList 즉 6개의 데이터를 보내준다. 반환값은 없다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 별 생성 및 북마크 추가 시 S3 키 정보가 포함되어 반환됩니다.
    - 별 생성 시 AI 서버로 별 데이터가 전송됩니다.
    - 사용순 상위 키워드 조회가 10개에서 30개로 확대되고, API 경로가 "/trending"으로 변경되었습니다.

- **버그 수정**
    - AI 서버로 데이터 전송 실패 시 새로운 오류 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->