### PR TITLE
SCRUM-204: 시나리오 1,2, 4 테스트 코드 작성

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/history/dto/request/CreateHistoryRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/history/dto/request/CreateHistoryRequestDTO.java
@@ -1,10 +1,14 @@
 package com.team_nebula.nebula.domain.history.dto.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class CreateHistoryRequestDTO {
 	private Double lastVisitTime;
 	private String title;

--- a/src/test/java/com/team_nebula/nebula/usecase/UsecaseTest.java
+++ b/src/test/java/com/team_nebula/nebula/usecase/UsecaseTest.java
@@ -1,0 +1,133 @@
+package com.team_nebula.nebula.usecase;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team_nebula.nebula.domain.history.dto.request.CreateHistoryRequestDTO;
+import com.team_nebula.nebula.global.oauth.dto.TokenResponseDTO;
+import com.team_nebula.nebula.global.oauth.service.CustomOAuth2UserService;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class UsecaseTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private CustomOAuth2UserService customOAuth2UserService;
+
+	private Cookie accessTokenCookie;
+	private Cookie refreshTokenCookie;
+
+	@BeforeEach
+	void setUp() {
+		TokenResponseDTO tokenResponseDTO = customOAuth2UserService.generate();
+		accessTokenCookie = new Cookie("accessToken", tokenResponseDTO.getAccessToken());
+		refreshTokenCookie = new Cookie("refreshToken", tokenResponseDTO.getRefreshToken());
+	}
+
+	@Test
+	@DisplayName("시나리오 1: 첫 번째 북마크 저장 및 조회")
+	void testSaveFirstBookmarkIntegration() throws Exception {
+		String title = "테스트 북마크";
+		String siteUrl = "https://www.naver.com";
+
+		MockMultipartFile htmlFile = new MockMultipartFile(
+			"htmlFile",
+			"bookmark.html",
+			"text/html",
+			"<html><body>북마크 테스트 페이지</body></html>".getBytes()
+		);
+
+		mockMvc.perform(multipart("/api/v2/stars")
+				.file(htmlFile)
+				.param("title", title)
+				.param("siteUrl", siteUrl)
+				.cookie(accessTokenCookie, refreshTokenCookie)
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.result.title").value(title))
+			.andExpect(jsonPath("$.result.siteUrl").value(siteUrl))
+			.andExpect(jsonPath("$.result.keywords").isArray())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("시나리오 2: 방문기록 수집 및 히스토리 리스트 조회")
+	void testHistoryScenario() throws Exception {
+		List<CreateHistoryRequestDTO> requests = new ArrayList<>();
+		requests.add(CreateHistoryRequestDTO.builder()
+			.lastVisitTime(1746898245.0)
+			.title("테스트 방문기록 1")
+			.typedCount(1L)
+			.url("https://example.com/1")
+			.visitCount(1L)
+			.build());
+		requests.add(CreateHistoryRequestDTO.builder()
+			.lastVisitTime(1746898246.0)
+			.title("테스트 방문기록 2")
+			.typedCount(1L)
+			.url("https://example.com/2")
+			.visitCount(1L)
+			.build());
+
+		mockMvc.perform(post("/api/v1/histories")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requests))
+				.cookie(accessTokenCookie, refreshTokenCookie))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andDo(print());
+
+		mockMvc.perform(get("/api/v1/histories")
+				.param("page", "0")
+				.param("size", "10")
+				.cookie(accessTokenCookie, refreshTokenCookie))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.result.content").isArray())
+			.andExpect(jsonPath("$.result.content[0].url").exists())
+			.andExpect(jsonPath("$.result.content[0].lastVisitTime").exists())
+			.andExpect(jsonPath("$.result.content[0].title").exists())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("시나리오 4: 키워드 기반 연관 콘텐츠 탐색")
+	void testKeywordBasedContentExploration() throws Exception {
+		String keywordName = "string";
+
+		mockMvc.perform(get("/api/v1/stars/keywords/{keywordId}", keywordName)
+				.cookie(accessTokenCookie, refreshTokenCookie))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.result.type").value("Keyword"))
+			.andExpect(jsonPath("$.result.starListDto").isArray())
+			.andExpect(jsonPath("$.result.linkListDto").isArray())
+			.andDo(print());
+	}
+}


### PR DESCRIPTION
## 💡 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🔨작업 사항
<!---- 어떤 변경 사항이 있나요?-->

## ⭐️ 토큰 쿠키에 설정
<img width="789" alt="image" src="https://github.com/user-attachments/assets/b999bc5d-8543-491f-883e-868b616150aa" />

`@BeforeEach`를 통해 토큰을 발급 받아 쿠키에 적용

## ⭐️ 시나리오 1: 첫 번째 북마크 저장 및 조회
1. **환경**
    - 김개발(대학생)이 Chrome 확장으로 NEBULA에 처음으로 북마크를 저장하려 함.
2. **흐름**
    1. Chrome 확장 아이콘 클릭 → “NEBULA에 북마크 추가” 선택
    2. AI가 자동 추출한 키워드(예: “TF-IDF”, “Neo4j”)를 확인하고 필요 시 편집
    3. 메모 입력 후 ‘저장’ 클릭
    4. NEBULA 웹 대시보드 접속 → 3D 그래프 상에 새 노드가 표시됨
    5. 노드 위에 마우스 오버 → 메모·키워드·요약 팝업 확인
## ⭐️ 시나리오 2: 방문기록 수집 및 히스토리 리스트 조회
1. **환경**
    - 이수자(취업 준비생)가 지난 며칠간 본 사이트를 돌아보고자 함.
2. **흐름**
    1. NEBULA 백엔드가 1시간 단위로 Chrome 방문기록을 자동 수집
    2. 대시보드 메뉴에서 ‘방문 기록’ 탭을 클릭
    3. 날짜 범위(예: 5/1–5/7) 선택 → 해당 기간의 방문 기록 리스트 확인
    4. 리스트에서 특정 항목 클릭 → 페이지 미리보기 및 방문 시간, URL, 스크린샷 확인
    5. 방문한 페이지를 북마크로 전환하거나 메모 추가

## ⭐️ 시나리오 4: 키워드 기반 연관 콘텐츠 탐색
1. **환경**
    - 박연구(석사 과정)가 챗봇에게 지난주에 본 그래프 관련 자료를 묻고자 함.
2. **흐름**
    1. 대시보드 우측 하단 챗봇 아이콘 클릭
    2. “지난주에 본 Graph 관련 자료 알려줘” 입력
    3. 챗봇이 AI로 질의 의도 파악 후, 지난 7일간 방문·북마크 기록 중 키워드 ‘Graph’가 포함된 항목 목록 응답
    4. 목록에서 원하는 항목 클릭 → 상세 뷰로 이동

## 📝 기타 (선택)
<!---- 참고 사항이나 리뷰어에게 전달하고 싶은 내용이 있나요?-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - 통합 테스트 클래스가 추가되어 북마크 저장/조회, 방문 기록 등록/조회, 키워드 기반 콘텐츠 탐색 시나리오가 검증됩니다.

- **스타일**
  - 데이터 객체에 빌더 패턴과 전체 필드 생성자가 추가되어 객체 생성이 더욱 유연해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->