### PR TITLE
SCRUM 208 : 스타 저장 후 AI 서버로 데이터전송 기능 추가

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/keyword/api/KeywordController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/api/KeywordController.java
@@ -41,8 +41,8 @@ public class KeywordController {
     }
 
     // 가장 많이 사용된 키워드 10개 조회 API
-    @Operation(summary = "사용순 상위 키워드 30개 조회", description = "가장 많이 사용되고 있는 상위 30개 키워드 이름리스트를 반환한다. 추가로 순위와 키워드가 사용된 횟수를 볼 수 있다.")
-    @GetMapping("/trending")
+    @Operation(summary = "사용순 상위 키워드 10개 조회", description = "가장 많이 사용되고 있는 상위 10개 키워드 이름리스트를 반환한다. 추가로 순위와 키워드가 사용된 횟수를 볼 수 있다.")
+    @GetMapping("/top10-used")
     public ApiResponse<GetMostUsedKeywordListResponseDTO> getKeywords() {
         GetMostUsedKeywordListResponseDTO mostUsedKeywordList = keywordQueryService.getMostUsedKeywordList();
         return ApiResponse.onSuccess(mostUsedKeywordList);

--- a/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/team_nebula/nebula/domain/keyword/repository/KeywordRepository.java
@@ -46,7 +46,7 @@ public interface KeywordRepository extends Neo4jRepository<Keyword, String> {
     WHERE (s.isDeletedStatus = false OR s.isDeletedStatus IS NULL)
     RETURN k.name AS keywordName, COUNT(s) AS usedCnt
     ORDER BY usedCnt DESC, keywordName ASC
-    LIMIT 30
+    LIMIT 10
     """)
     List<GetMostUsedKeywordOneResponseDTO> getMostUsedKeywordList();
 

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/request/CreateStarRequestDTO.java
@@ -20,7 +20,6 @@ public class CreateStarRequestDTO {
     private String userMemo;
     private String categoryName;
     private List<String> keywordList;
-    private String s3key;
 
     public String getSummaryAI() {
         if (summaryAI == null || summaryAI.isBlank()) {

--- a/src/main/java/com/team_nebula/nebula/domain/star/dto/response/AddBookMarkResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/dto/response/AddBookMarkResponseDTO.java
@@ -17,5 +17,4 @@ public class AddBookMarkResponseDTO {
     private String thumbnailUrl;
     private String faviconUrl;
     private List<String> keywords;
-    private String s3key;
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -226,7 +226,6 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .faviconUrl(favicon.getFaviconUrl())
                 .thumbnailUrl(responseDTO.getImage_url())
                 .keywords(responseDTO.getKeywords())
-                .s3key(htmlFileKey)
                 .build();
     }
 
@@ -274,7 +273,6 @@ public class StarCommandServiceImpl implements StarCommandService {
 
         // 유저 스타 작업 횟수 증가
 //        aiService.checkUpdatedCnt(userId);
-        aiMessageService.sendStarData(userId, lastStar, requestDTO.getS3key(), lastStar.getUserMemo(), lastStar.getSummaryAI(), requestDTO.getKeywordList());
 
         return CreateStarResponseDTO.builder()
                 .starId(lastStar.getId())

--- a/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
+++ b/src/main/java/com/team_nebula/nebula/global/AI/service/AiMessageService.java
@@ -1,7 +1,7 @@
 package com.team_nebula.nebula.global.AI.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.team_nebula.nebula.domain.star.entity.Star;
+import com.team_nebula.nebula.domain.star.dto.request.AnalyzeHtmlRequestDTO;
 import com.team_nebula.nebula.global.AI.dto.GetThumbnailAndKeywordsResponseDTO;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Service
@@ -24,9 +23,6 @@ public class AiMessageService {
 
     @Value("${rabbitmq.queue.extract-data}")
     private String extractDataQueue;
-
-    @Value("${rabbitmq.queue.save-data}")
-    private String saveDataQueue;
 
     public GetThumbnailAndKeywordsResponseDTO analyzeHtmlFile(Long userId, String htmlFileKey) {
         try {
@@ -52,24 +48,6 @@ public class AiMessageService {
 
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus._AI_EXTRACT_DATA_ERROR);
-        }
-    }
-
-    public void sendStarData(Long userId, Star star, String s3key, String userMemo, String summaryAI, List<String> keywordList){
-        try {
-            Map<String, Object> message = new HashMap<>();
-            message.put("userId", userId);
-            message.put("starId", star.getId().toString());
-            message.put("s3Key", s3key);
-            message.put("memo", userMemo);
-            message.put("summary", summaryAI);
-            message.put("keywords", keywordList);
-
-            String jsonMessage = objectMapper.writeValueAsString(message);
-
-            rabbitTemplate.convertAndSend(saveDataQueue, jsonMessage);
-        } catch (Exception e) {
-            throw new GeneralException(ErrorStatus._AI_STAR_DATA_SEND_ERROR);
         }
     }
 }

--- a/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/team_nebula/nebula/global/apipayload/code/status/ErrorStatus.java
@@ -33,9 +33,8 @@ public enum ErrorStatus implements BaseErrorCode {
 	_MULTIPARTFILE_CONVERT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,"MULTIPARTFILE5000","MultipartFile -> File로 변환이 실패하였습니다."),
 
 	_AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5000","AI 서버에서 문제가 발생했습니다."),
-	_AI_EXTRACT_DATA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5001","AI 에서 썸네일과 추천 키워드을 가져오지 못했습니다."),
+	_AI_EXTRACT_DATA_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5001","AI에서 썸네일과 추천 키워드을 가져오지 못했습니다."),
 	_AI_KEYWORD_SYNC_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5002","AI Keyword sync 호출에 실해하였습니다."),
-	_AI_STAR_DATA_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI5003","AI 서버로 데이터 전송이 실패하였습니다."),
 
 	_S3_HTML_FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S35001", "S3에 저장된 html 파일을 삭제하는데 실패했습니다."),
 


### PR DESCRIPTION
Reverts TU-NEBULA/nebula-backend#80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 상위 10개 사용 키워드 조회 API 경로가 `/top10-used`로 변경되고, 반환 개수가 10개로 조정되었습니다.

- **버그 수정**
    - 일부 오류 메시지의 오타가 수정되었습니다.

- **리팩터**
    - 즐겨찾기 및 별 생성 시 S3 관련 필드와 AI 메시지 전송 기능이 제거되었습니다.
    - 관련 불필요한 필드와 메서드, 에러 코드가 삭제되어 코드가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->