### PR TITLE
SCRUM 211 : tistory 파비콘 통일 및 S3 파일 url 에러 해결

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/favicon/service/FaviconServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/favicon/service/FaviconServiceImpl.java
@@ -5,6 +5,7 @@ import com.team_nebula.nebula.domain.favicon.repository.FaviconRepository;
 import com.team_nebula.nebula.global.image.FaviconDownloader;
 import com.team_nebula.nebula.global.image.S3Service;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,22 +19,30 @@ public class FaviconServiceImpl implements FaviconService {
     private final FaviconRepository faviconRepository;
     private final S3Service s3Service;
 
+    @Value("${favicon.tistory-default}")
+    private String tistoryDefaultFavicon;
+
     @Override
     public Favicon getOrCreateFavicon(String siteUrl) {
-        // 1. 도메인 추출
+        // 도메인 추출
         String domain = extractDomain(siteUrl);
 
-        // 2. 기존 Favicon이 있는지 확인
+        // tistoy일 경우 체크
+        if (domain.equals("tistory.com") || domain.endsWith(".tistory.com")) {
+            domain = tistoryDefaultFavicon;
+        }
+
+        // 기존 Favicon이 있는지 확인
         Optional<Favicon> existingFavicon = faviconRepository.findById(domain);
         if (existingFavicon.isPresent()) {
             return existingFavicon.get();
         }
 
-        // 3. 파비콘 다운로드 후 S3 업로드
+        // 파비콘 다운로드 후 S3 업로드
         File faviconFile = downloadFavicon(domain);
         String faviconUrl = s3Service.saveFavicon(faviconFile, domain);
 
-        // 4. 새로운 Favicon 노드 저장 후 반환
+        // 새로운 Favicon 노드 저장 후 반환
         Favicon newFavicon = new Favicon(domain, faviconUrl);
         return faviconRepository.save(newFavicon);
     }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -54,7 +54,8 @@ public class StarCommandServiceImpl implements StarCommandService {
         UserNode userNode = userNodeRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-        String htmlFileKey = s3Service.saveHtmlFile(htmlFile, title);
+        String sanitizedTitle = s3Service.sanitizeTitleForS3(title);
+        String htmlFileKey = s3Service.saveHtmlFile(htmlFile, sanitizedTitle);
 
         Star star = Star.builder()
                 .title(title)

--- a/src/main/java/com/team_nebula/nebula/global/image/S3Service.java
+++ b/src/main/java/com/team_nebula/nebula/global/image/S3Service.java
@@ -132,5 +132,23 @@ public class S3Service {
             throw new GeneralException(ErrorStatus._S3_HTML_FILE_DELETE_FAIL);
         }
     }
+
+    public String sanitizeTitleForS3(String title) {
+        if (title == null) return "";
+
+        // 1. 공백을 하나로 정규화
+        title = title.replaceAll("\\s+", " ");
+
+        // 2. 한글, 영문, 숫자, '-', '_', '.', '~', 공백만 허용 (이모티콘, 특수문자, 대괄호 등 제거)
+        title = title.replaceAll("[^가-힣a-zA-Z0-9\\-_.~ ]", "");
+
+        // 3. 공백을 하이픈으로 변환
+        title = title.replace(" ", "-");
+
+        // 4. 소문자로 변환
+        title = title.toLowerCase();
+
+        return title;
+    }
 }
 


### PR DESCRIPTION
## 💡 개요
 tistory 파비콘 통일 및 S3 파일 url 에러 해결

## 🔨작업 사항
### 1. tistory 파비콘 통일
- 현재 S3 버킷에 tistory.com 기본 파비콘을 업로드함
- 북마크 추가 기능 수행할 때 siteUrl에서 tistory를 감지하고 기본 파비콘을 가져오게 수정함

### 2. html 파일의 S3 주소 생성시 특수기호로 인한 에러 해결
```
public String sanitizeTitleForS3(String title) {
        if (title == null) return "";

        // 1. 공백을 하나로 정규화
        title = title.replaceAll("\\s+", " ");

        // 2. 한글, 영문, 숫자, '-', '_', '.', '~', 공백만 허용 (이모티콘, 특수문자, 대괄호 등 제거)
        title = title.replaceAll("[^가-힣a-zA-Z0-9\\-_.~ ]", "");

        // 3. 공백을 하이픈으로 변환
        title = title.replace(" ", "-");

        // 4. 소문자로 변환
        title = title.toLowerCase();

        return title;
    }
```
- S3Service에서 따로 title 정제용 메서드를 구현함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- S3 저장소에 HTML 파일을 저장할 때 제목을 안전하게 변환하여 사용할 수 있도록 제목 정제 기능이 추가되었습니다.
- **버그 수정**
	- 티스토리(tistory.com) 관련 도메인에 대해 파비콘 처리 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->