### PR TITLE
SCRUM-233: 채팅 세션 정보 변경 API 구현

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/api/ChatbotController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/api/ChatbotController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -47,6 +48,15 @@ public class ChatbotController {
 		@RequestParam(name = "limit", defaultValue = "20") int limit,
 		@RequestParam(name = "offset", defaultValue = "0") int offset) {
 		return ApiResponse.onSuccess(chatbotService.getSessions(userId, limit, offset));
+	}
+
+	@Operation(summary = "채팅 세션 정보 수정", description = "채팅 세션 정보를 수정하는 API")
+	@PutMapping("/sessions/{sessionId}")
+	public ApiResponse<SessionListResponseDTO> updateSession(
+		@AuthUser Long userId,
+		@PathVariable String sessionId,
+		@RequestBody SessionRequestDTO request) {
+		return ApiResponse.onSuccess(chatbotService.updateSession(userId, sessionId, request));
 	}
 
 	@Operation(summary = "채팅 스트림", description = "채팅 세션에서 메시지를 스트리밍하는 API")

--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotService.java
@@ -15,6 +15,8 @@ public interface ChatbotService {
 
 	List<SessionListResponseDTO> getSessions(Long userId, int limit, int offset);
 
+	SessionListResponseDTO updateSession(Long userId, String sessionId, SessionRequestDTO request);
+
 	SessionResponseDTO createSession(Long userId, SessionRequestDTO request);
 
 	List<CharResponseDTO> getSessionMessages(Long userId, String sessionId);

--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotServiceImpl.java
@@ -138,6 +138,42 @@ public class ChatbotServiceImpl implements ChatbotService {
 	}
 
 	@Override
+	public SessionListResponseDTO updateSession(Long userId, String sessionId, SessionRequestDTO request) {
+		try {
+			String url = String.format("%s/chat/sessions/%s?user_id=%d", aiChatUrl, sessionId, userId);
+
+			Map<String, Object> requestBody = new HashMap<>();
+			requestBody.put("title", request.getTitle());
+
+			String response = webClient.put()
+				.uri(url)
+				.contentType(MediaType.APPLICATION_JSON)
+				.bodyValue(requestBody)
+				.retrieve()
+				.bodyToMono(String.class)
+				.block();
+
+			log.info("AI 서버 세션 업데이트 응답: {}", response);
+
+			JsonNode root = objectMapper.readTree(response);
+			JsonNode data = root.path("data");
+
+			return SessionListResponseDTO.builder()
+				.sessionId(getText(data, "id"))
+				.title(getText(data, "title"))
+				.sessionType(getText(data, "session_type"))
+				.createdAt(getText(data, "created_at"))
+				.updatedAt(getText(data, "updated_at"))
+				.isActive(data.path("is_active").asBoolean(true))
+				.build();
+
+		} catch (Exception e) {
+			log.error("세션 업데이트 중 오류 발생", e);
+			throw new GeneralException(ErrorStatus._AI_CHATBOT_ERROR);
+		}
+	}
+
+	@Override
 	public SseEmitter chatStream(Long userId, ChatRequestDTO request) {
 		SseEmitter emitter = new SseEmitter(300_000L);
 


### PR DESCRIPTION
## 💡 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

채팅 세션의 제목을 수정할 수 있는 API 기능을 구현

## 🔨작업 사항

## ChatbotServiceImpl.updateSession 메소드 구현
AI 서버와의 PUT 통신을 통해 세션 정보 업데이트
요청 URL: {aiChatUrl}/chat/sessions/{sessionId}?user_id={userId}
requestBody에 `title` 정보 포함
AI 서버 응답을 파싱하여 SessionListResponseDTO 객체로 변환

## API 엔드포인트
PUT /api/v1/chat/sessions/{sessionId}
요청 예시:
```
{
    "title": "새로운 세션 제목"
}
```

## 📝 기타 (선택)
<!---- 참고 사항이나 리뷰어에게 전달하고 싶은 내용이 있나요?-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to update chat session information through a new API endpoint. Users can now modify session details for existing chat sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->