### PR TITLE
SCRUM-234: Swagger Basic Auth 추가

### DIFF
--- a/src/main/java/com/team_nebula/nebula/global/config/SecurityConfig.java
+++ b/src/main/java/com/team_nebula/nebula/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -53,6 +54,25 @@ public class SecurityConfig {
 	}
 
 	@Bean
+	@Order(1)
+	public SecurityFilterChain swaggerSecurityFilterChain(HttpSecurity http) throws Exception {
+
+		http.
+			securityMatcher("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**");
+		http
+			.csrf(csrf -> csrf.disable());
+		http
+			.httpBasic(httpBasic -> httpBasic.realmName("Swagger API Documentation"));
+		http
+			.authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+		http
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+		return http.build();
+	}
+
+	@Bean
+	@Order(2)
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
 		http


### PR DESCRIPTION
## 💡 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
Swagger UI 및 관련 API 문서 경로에 대해 HTTP Basic 인증을 적용하여 접근을 제한하도록 설정
인증 없이 누구나 문서에 접근할 수 있는 보안 취약점을 방지

## 🔨작업 사항
<!---- 어떤 변경 사항이 있나요?-->
- SecurityFilterChain을 @Order(1)으로 추가하여 Swagger 관련 요청(/swagger-ui/**, /v3/api-docs/** 등)에 대한 Basic Auth 먼저 적용

- http.httpBasic() 설정으로 인증 팝업 동작

## 📝 기타 (선택)
<!---- 참고 사항이나 리뷰어에게 전달하고 싶은 내용이 있나요?-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced security for API documentation endpoints, requiring authentication to access Swagger UI and related resources.

* **Refactor**
  * Updated security configuration to ensure proper ordering and separation between general application security and API documentation security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->