### PR TITLE
SCRUM-241: 채팅 세션 메시지 조회 페이지네이션

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/api/ChatbotController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/api/ChatbotController.java
@@ -16,6 +16,7 @@ import com.team_nebula.nebula.domain.chatbot.dto.request.ChatRequestDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.request.SessionRequestDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.CharResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionListResponseDTO;
+import com.team_nebula.nebula.domain.chatbot.dto.response.SessionsResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.service.ChatbotService;
 import com.team_nebula.nebula.global.annotation.AuthUser;
@@ -43,7 +44,7 @@ public class ChatbotController {
 
 	@Operation(summary = "사용자 채팅 세션 목록 조회", description = "사용자 채팅 세션 목록을 조회하는 API")
 	@GetMapping("/sessions")
-	public ApiResponse<List<SessionListResponseDTO>> getSessions(
+	public ApiResponse<SessionsResponseDTO> getSessions(
 		@AuthUser Long userId,
 		@RequestParam(name = "limit", defaultValue = "20") int limit,
 		@RequestParam(name = "offset", defaultValue = "0") int offset) {

--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/api/ChatbotController.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/api/ChatbotController.java
@@ -1,7 +1,5 @@
 package com.team_nebula.nebula.domain.chatbot.api;
 
-import java.util.List;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,10 +12,10 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.team_nebula.nebula.domain.chatbot.dto.request.ChatRequestDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.request.SessionRequestDTO;
-import com.team_nebula.nebula.domain.chatbot.dto.response.CharResponseDTO;
+import com.team_nebula.nebula.domain.chatbot.dto.response.ChatResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionListResponseDTO;
-import com.team_nebula.nebula.domain.chatbot.dto.response.SessionsResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionResponseDTO;
+import com.team_nebula.nebula.domain.chatbot.dto.response.SessionsResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.service.ChatbotService;
 import com.team_nebula.nebula.global.annotation.AuthUser;
 import com.team_nebula.nebula.global.apipayload.ApiResponse;
@@ -70,9 +68,11 @@ public class ChatbotController {
 
 	@Operation(summary = "채팅 세션 메시지 조회", description = "채팅 세션의 메시지를 조회하는 API")
 	@GetMapping("/sessions/{sessionId}/messages")
-	public ApiResponse<List<CharResponseDTO>> getSessionMessages(
+	public ApiResponse<ChatResponseDTO> getSessionMessages(
 		@AuthUser Long userId,
-		@PathVariable String sessionId) {
-		return ApiResponse.onSuccess(chatbotService.getSessionMessages(userId, sessionId));
+		@PathVariable String sessionId,
+		@RequestParam(name = "page", defaultValue = "1") int page,
+		@RequestParam(name = "size", defaultValue = "20") int size) {
+		return ApiResponse.onSuccess(chatbotService.getSessionMessages(userId, sessionId, page, size));
 	}
 }

--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/dto/response/ChatResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/dto/response/ChatResponseDTO.java
@@ -11,8 +11,10 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CharResponseDTO {
+public class ChatResponseDTO {
 	private String sessionId;
+
 	private List<MessageResponseDTO> messages;
 
-}
+	private PaginationResponseDTO pagination;
+} 

--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/dto/response/PaginationResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/dto/response/PaginationResponseDTO.java
@@ -1,0 +1,28 @@
+package com.team_nebula.nebula.domain.chatbot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaginationResponseDTO {
+	private int currentPage;
+
+	private int pageSize;
+
+	private int totalCount;
+
+	private int totalPages;
+
+	private boolean hasNext;
+
+	private boolean hasPrev;
+
+	private Integer nextPage;
+
+	private Integer prevPage;
+} 

--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/dto/response/SessionsResponseDTO.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/dto/response/SessionsResponseDTO.java
@@ -1,0 +1,17 @@
+package com.team_nebula.nebula.domain.chatbot.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SessionsResponseDTO {
+	private List<SessionListResponseDTO> sessions;
+	private int total;
+} 

--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotService.java
@@ -1,15 +1,13 @@
 package com.team_nebula.nebula.domain.chatbot.service;
 
-import java.util.List;
-
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.team_nebula.nebula.domain.chatbot.dto.request.ChatRequestDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.request.SessionRequestDTO;
-import com.team_nebula.nebula.domain.chatbot.dto.response.CharResponseDTO;
+import com.team_nebula.nebula.domain.chatbot.dto.response.ChatResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionListResponseDTO;
-import com.team_nebula.nebula.domain.chatbot.dto.response.SessionsResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionResponseDTO;
+import com.team_nebula.nebula.domain.chatbot.dto.response.SessionsResponseDTO;
 
 public interface ChatbotService {
 	SseEmitter chatStream(Long userId, ChatRequestDTO request);
@@ -20,5 +18,5 @@ public interface ChatbotService {
 
 	SessionResponseDTO createSession(Long userId, SessionRequestDTO request);
 
-	List<CharResponseDTO> getSessionMessages(Long userId, String sessionId);
+	ChatResponseDTO getSessionMessages(Long userId, String sessionId, int page, int size);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotService.java
@@ -8,12 +8,13 @@ import com.team_nebula.nebula.domain.chatbot.dto.request.ChatRequestDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.request.SessionRequestDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.CharResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionListResponseDTO;
+import com.team_nebula.nebula.domain.chatbot.dto.response.SessionsResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionResponseDTO;
 
 public interface ChatbotService {
 	SseEmitter chatStream(Long userId, ChatRequestDTO request);
 
-	List<SessionListResponseDTO> getSessions(Long userId, int limit, int offset);
+	SessionsResponseDTO getSessions(Long userId, int limit, int offset);
 
 	SessionListResponseDTO updateSession(Long userId, String sessionId, SessionRequestDTO request);
 

--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotServiceImpl.java
@@ -17,8 +17,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team_nebula.nebula.domain.chatbot.dto.request.ChatRequestDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.request.SessionRequestDTO;
-import com.team_nebula.nebula.domain.chatbot.dto.response.CharResponseDTO;
+import com.team_nebula.nebula.domain.chatbot.dto.response.ChatResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.MessageResponseDTO;
+import com.team_nebula.nebula.domain.chatbot.dto.response.PaginationResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionListResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionsResponseDTO;
@@ -235,9 +236,10 @@ public class ChatbotServiceImpl implements ChatbotService {
 	}
 
 	@Override
-	public List<CharResponseDTO> getSessionMessages(Long userId, String sessionId) {
+	public ChatResponseDTO getSessionMessages(Long userId, String sessionId, int page, int size) {
 		try {
-			String url = String.format("%s/chat/sessions/%s/messages?user_id=%d", aiChatUrl, sessionId, userId);
+			String url = String.format("%s/chat/sessions/%s/messages?user_id=%d&page=%d&size=%d",
+				aiChatUrl, sessionId, userId, page, size);
 
 			HttpHeaders headers = new HttpHeaders();
 			headers.setContentType(MediaType.APPLICATION_JSON);
@@ -256,6 +258,7 @@ public class ChatbotServiceImpl implements ChatbotService {
 
 			String receivedSessionId = getText(data, "session_id");
 			JsonNode messagesNode = data.path("messages");
+			JsonNode paginationNode = data.path("pagination");
 
 			List<MessageResponseDTO> messageList = new ArrayList<>();
 
@@ -272,12 +275,22 @@ public class ChatbotServiceImpl implements ChatbotService {
 				}
 			}
 
-			CharResponseDTO responseDto = CharResponseDTO.builder()
-				.sessionId(receivedSessionId)
-				.messages(messageList)
+			PaginationResponseDTO pagination = PaginationResponseDTO.builder()
+				.currentPage(paginationNode.path("current_page").asInt(1))
+				.pageSize(paginationNode.path("page_size").asInt(20))
+				.totalCount(paginationNode.path("total_count").asInt(0))
+				.totalPages(paginationNode.path("total_pages").asInt(0))
+				.hasNext(paginationNode.path("has_next").asBoolean(false))
+				.hasPrev(paginationNode.path("has_prev").asBoolean(false))
+				.nextPage(paginationNode.path("next_page").isNull() ? null : paginationNode.path("next_page").asInt())
+				.prevPage(paginationNode.path("prev_page").isNull() ? null : paginationNode.path("prev_page").asInt())
 				.build();
 
-			return List.of(responseDto);
+			return ChatResponseDTO.builder()
+				.sessionId(receivedSessionId)
+				.messages(messageList)
+				.pagination(pagination)
+				.build();
 
 		} catch (Exception e) {
 			log.error("세션 메시지 조회 중 오류 발생", e);

--- a/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/chatbot/service/ChatbotServiceImpl.java
@@ -21,6 +21,7 @@ import com.team_nebula.nebula.domain.chatbot.dto.response.CharResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.MessageResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionListResponseDTO;
 import com.team_nebula.nebula.domain.chatbot.dto.response.SessionResponseDTO;
+import com.team_nebula.nebula.domain.chatbot.dto.response.SessionsResponseDTO;
 import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 
@@ -79,7 +80,7 @@ public class ChatbotServiceImpl implements ChatbotService {
 	}
 
 	@Override
-	public List<SessionListResponseDTO> getSessions(Long userId, int limit, int offset) {
+	public SessionsResponseDTO getSessions(Long userId, int limit, int offset) {
 		try {
 			String url = String.format("%s/chat/sessions?user_id=%d&limit=%d&offset=%d", aiChatUrl, userId, limit,
 				offset);
@@ -101,16 +102,23 @@ public class ChatbotServiceImpl implements ChatbotService {
 		}
 	}
 
-	private List<SessionListResponseDTO> parseSessionsFromResponse(String responseBody) {
+	private SessionsResponseDTO parseSessionsFromResponse(String responseBody) {
 		List<SessionListResponseDTO> sessions = new ArrayList<>();
+		int total = 0;
 
 		try {
 			JsonNode root = objectMapper.readTree(responseBody);
-			JsonNode sessionsNode = root.path("data").path("sessions");
+			JsonNode dataNode = root.path("data");
+			JsonNode sessionsNode = dataNode.path("sessions");
+
+			total = dataNode.path("total").asInt(0);
 
 			if (!sessionsNode.isArray()) {
 				log.warn("세션 목록이 배열이 아닙니다.");
-				return sessions;
+				return SessionsResponseDTO.builder()
+					.sessions(sessions)
+					.total(total)
+					.build();
 			}
 
 			for (JsonNode sessionNode : sessionsNode) {
@@ -129,7 +137,10 @@ public class ChatbotServiceImpl implements ChatbotService {
 			log.error("AI 세션 목록 JSON 파싱 실패", e);
 		}
 
-		return sessions;
+		return SessionsResponseDTO.builder()
+			.sessions(sessions)
+			.total(total)
+			.build();
 	}
 
 	private String getText(JsonNode node, String fieldName) {


### PR DESCRIPTION
## 💡 개요
채팅 세션 메시지 조회 API에 페이지네이션 기능을 추가, 기존 단순한 메시지 목록 응답을 페이지네이션 정보가 포함된 응답 구조로 변경하여 클라이언트에서 페이지 기반 탐색이 가능하도록 했습니다.

## 🔨작업 사항
- 채팅 세션 메시지 조회 페이지네이션 적용
- 사용자 채팅 세션 목록 조회 total 응답 추가

## 📝 기타 (선택)
<!---- 참고 사항이나 리뷰어에게 전달하고 싶은 내용이 있나요?-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination support for retrieving chat session messages, allowing users to specify page number and size.
  * Session list and message retrieval APIs now provide total counts and pagination details in responses.

* **Bug Fixes**
  * Corrected a class name typo in response data for chat messages.

* **Refactor**
  * Enhanced response structures for session and message retrieval to deliver more comprehensive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->