### PR TITLE
SCRUM 236 : 최근 검색어 기능 리팩토링

### DIFF
--- a/src/main/java/com/team_nebula/nebula/domain/star/api/StarV2Controller.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/api/StarV2Controller.java
@@ -80,6 +80,7 @@ public class StarV2Controller {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
+        starCommandService.saveRecentSearches(userId, query);
         SearchResultResponseDTO result = starQueryService.searchStarsV2(query, userId, page, size);
         return ApiResponse.onSuccess(result);
     }
@@ -92,5 +93,12 @@ public class StarV2Controller {
     ) {
         List<String> suggestions = starQueryService.getAutoComplete(query, userId, 5);
         return ApiResponse.onSuccess(suggestions);
+    }
+
+    @Operation(summary = "최근 검색어 조회", description = "사용자 최근 검색어 10개 조회")
+    @GetMapping("/recent-searches")
+    public ApiResponse<List<String>> getRecentSearches(@AuthUser Long userId) {
+        List<String> recentSearches = starQueryService.getRecentSearches(userId);
+        return ApiResponse.onSuccess(recentSearches);
     }
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/search/service/ElasticsearchService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/search/service/ElasticsearchService.java
@@ -177,7 +177,7 @@ public class ElasticsearchService {
         }
     }
 
-    // 새로운 검색 메서드 (다른 용도로 사용)
+    //  검색 메서드 (더 넓은 범위 검색)
     @Cacheable(value = "starSearch", key = "#userId + '_' + #keyword + '_' + #page + '_' + #size")
     public List<StarSearchDocument> searchStarsSimple(Long userId, String keyword, int page, int size) {
         try {

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandService.java
@@ -6,6 +6,7 @@ import com.team_nebula.nebula.domain.star.dto.request.UpdateStarOneRequestDTO;
 import com.team_nebula.nebula.domain.star.dto.response.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface StarCommandService {
@@ -23,4 +24,9 @@ public interface StarCommandService {
     public AddBookMarkResponseDTO addBookMark(Long userId, MultipartFile htmlFile, String title, String siteUrl);
 
     public CreateStarResponseDTO createStar(Long userId, CreateStarRequestDTO requestDTO);
+
+    public void saveRecentSearches(Long userId, String keyword);
+
+    public void deleteRecentSearch(Long userId, String keyword);
+
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarCommandServiceImpl.java
@@ -29,17 +29,23 @@ import com.team_nebula.nebula.global.apipayload.code.status.ErrorStatus;
 import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 import java.time.OffsetDateTime;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static org.springframework.data.neo4j.core.ReactiveNeo4jClient.log;
 
 @Service
 @RequiredArgsConstructor
@@ -58,6 +64,9 @@ public class StarCommandServiceImpl implements StarCommandService {
     private final AiMessageService aiMessageService;
     private final FaviconRepository faviconRepository;
     private final ApplicationEventPublisher eventPublisher;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final int MAX_RECENT_SEARCHES = 10;
 
 
     @Override
@@ -314,5 +323,32 @@ public class StarCommandServiceImpl implements StarCommandService {
                 .build();
     }
 
+    @Override
+    @Async
+    public void saveRecentSearches(Long userId, String keyword){
+        try {
+            String key = "recent_search:" + userId;
+            String normalizedKeyword = keyword.trim().toLowerCase();
+
+            // 중복 제거
+            redisTemplate.opsForList().remove(key, 0, normalizedKeyword);
+            redisTemplate.opsForList().leftPush(key, normalizedKeyword);
+            redisTemplate.opsForList().trim(key, 0, MAX_RECENT_SEARCHES - 1);
+            redisTemplate.expire(key, Duration.ofDays(30));
+        }
+        catch (Exception e) {
+            log.error(e, "Failed to save recent search");
+        }
+    }
+
+    @Override
+    public void deleteRecentSearch(Long userId, String keyword) {
+        try {
+            String key = "recent_search:" + userId;
+            redisTemplate.opsForList().remove(key, 0, keyword.trim().toLowerCase());
+        } catch (Exception e) {
+            log.error(e, "Failed to delete recent search");
+        }
+    }
 
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryService.java
@@ -38,4 +38,5 @@ public interface StarQueryService {
 
 	public List<String> getAutoComplete(String query, Long userId, int size);
 
+	public List<String> getRecentSearches(Long userId);
 }

--- a/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
+++ b/src/main/java/com/team_nebula/nebula/domain/star/service/StarQueryServiceImpl.java
@@ -5,11 +5,11 @@ import java.util.stream.Collectors;
 
 import com.team_nebula.nebula.domain.star.dto.response.*;
 import com.team_nebula.nebula.domain.star.repository.StarNeo4jRepositoryCustom;
-import com.team_nebula.nebula.domain.star.search.document.StarSearchDocument;
 import com.team_nebula.nebula.domain.star.search.dto.response.SearchResultResponseDTO;
 import com.team_nebula.nebula.domain.star.search.dto.response.SearchStarResponseDTO;
 import com.team_nebula.nebula.domain.star.search.service.ElasticsearchService;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +21,8 @@ import com.team_nebula.nebula.global.apipayload.exception.GeneralException;
 
 import lombok.RequiredArgsConstructor;
 
+import static org.springframework.data.neo4j.core.ReactiveNeo4jClient.log;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -30,6 +32,9 @@ public class StarQueryServiceImpl implements StarQueryService {
 	private final LinkQueryService linkQueryService;
 	private final StarNeo4jRepositoryCustom starNeo4jRepositoryCustom;
 	private final ElasticsearchService elasticsearchService;
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private static final int MAX_RECENT_SEARCHES = 10;
 
 	// 스타 + 링크 전체 조회
 	@Override
@@ -164,8 +169,6 @@ public class StarQueryServiceImpl implements StarQueryService {
 				.build();
 	}
 
-
-
 	@Override
 	public List<String> getAutoComplete(String query, Long userId, int size) {
 
@@ -180,5 +183,21 @@ public class StarQueryServiceImpl implements StarQueryService {
 		}
 		return elasticsearchService.getAutoComplete(query, userId, size);
 
+	}
+
+	@Override
+	@Cacheable(value = "recent_searches", key = "#userId")
+	public List<String> getRecentSearches(Long userId) {
+		try {
+			String key = "recent_searches"+userId.toString();
+			List<Object> searches = redisTemplate.opsForList().range(key, 0, MAX_RECENT_SEARCHES - 1);
+			return searches.stream()
+					.map(Object::toString)
+					.collect(Collectors.toList());
+		}
+		catch (Exception e) {
+			log.error(e, "Failed to get recent searches");
+			return Collections.emptyList();
+		}
 	}
 }


### PR DESCRIPTION
## 💡 개요
최근 검색어 조회 및 검색 시 검색어 캐시 저장 기능 구현

## 🔨작업 사항
- 사용자가 검색 결과를 최대 10개 까지 캐시에 저장함
- 구현된 기능을 통해 사용자가 검색창을 누르면 최근 검색어 10개를 조회할 수 있음



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recent search queries are now recorded when you perform a search.
  * Added an endpoint to view your last 10 recent search queries.
  * Users can remove individual recent search keywords from their history.

* **Bug Fixes**
  * Improved reliability and error handling for recent search history features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->